### PR TITLE
Add developer debug pane

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,21 @@
+Implement GitHub issue #$ARGUMENTS from this repository.
+
+## Steps
+
+1. **Read the issue** — run `gh issue view $ARGUMENTS` to get the full title, description, and any implementation notes.
+
+2. **Explore** — identify all files the issue touches. Re-read the relevant sections of CLAUDE.md to make sure the implementation follows established patterns (server actions, auth, typing, component boundaries).
+
+3. **Implement** — make the changes. Follow every rule in CLAUDE.md: strict typing, no `useMemo`/`useCallback`, server-side mutations via Server Actions, validate at boundaries, no heavy UI libs.
+
+4. **Verify** — run `npm run lint` and fix any issues. If the change is UI-facing, start the dev server and confirm the feature works end-to-end, including edge cases.
+
+5. **Create a PR** — once everything looks good, create a pull request:
+   - `gh pr create` with a clear title and a body that references the issue (`Closes #$ARGUMENTS`), summarises what changed, and includes a short test plan.
+   - Do not push or create the PR until the implementation is complete and lint passes.
+
+## Constraints
+
+- Never skip steps to go faster — a working implementation is the only acceptable outcome.
+- If the issue description is ambiguous on a specific detail, make the most conservative reasonable choice and note it in the PR body.
+- Do not implement anything beyond what the issue describes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,18 @@ There is no test runner configured beyond `bbva-parser.test.ts` (which appears t
 - Temporary docs, notes, and instructions go in `temp/`.
 - Do not create multiple instruction files for a single feature.
 
+## Planning Workflow
+
+When asked to plan a new feature, follow this flow:
+
+1. **Explore** the codebase to understand what's relevant (existing patterns, types, actions, components).
+2. **Clarify** any ambiguous requirements with the user before designing.
+3. **Design** a concrete implementation plan: files to create/modify, functions to write, reuse opportunities.
+4. **Get approval** via `ExitPlanMode`.
+5. **Create a GitHub issue** with the approved plan via `gh issue create`. The issue body must include enough context for a separate Claude instance to implement it cold — architecture notes, key file paths, FK ordering, auth patterns, relevant existing utilities, and a verification checklist.
+
+Implementation is handled separately (by another instance working off the issue), so the issue is the deliverable — not a local plan file.
+
 ## Environment Variables
 
 Required in `.env.local` (and Vercel for production):

--- a/src/app/actions/debug-actions.ts
+++ b/src/app/actions/debug-actions.ts
@@ -1,0 +1,178 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+interface ActionResult {
+  success: boolean;
+  error?: string;
+  message?: string;
+}
+
+const SEED_CATEGORIES = {
+  income: [
+    { name: "Salary", color: "#0d9488" },
+    { name: "Freelance", color: "#22c55e" },
+  ],
+  expense: [
+    { name: "Groceries", color: "#ef4444" },
+    { name: "Rent", color: "#7f1d1d" },
+    { name: "Entertainment", color: "#7c3aed" },
+    { name: "Transport", color: "#2563eb" },
+    { name: "Dining", color: "#f97316" },
+  ],
+};
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+export async function seedFakeTransactions(): Promise<ActionResult> {
+  if (process.env.NODE_ENV !== "development") {
+    return { success: false, error: "dev only" };
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return { success: false, error: "User not authenticated" };
+    }
+
+    const { data: existingCategories } = await supabase
+      .from("categories")
+      .select("*")
+      .eq("user_id", user.id);
+
+    const cats = existingCategories || [];
+    const categoryMap: Record<string, string> = {};
+
+    for (const c of cats) {
+      categoryMap[c.name] = c.id;
+    }
+
+    if (cats.length < 2) {
+      for (const cat of SEED_CATEGORIES.income) {
+        if (!categoryMap[cat.name]) {
+          const { data } = await supabase
+            .from("categories")
+            .insert({ name: cat.name, category_type: "income", color: cat.color, user_id: user.id })
+            .select("id, name")
+            .single();
+          if (data) categoryMap[data.name] = data.id;
+        }
+      }
+      for (const cat of SEED_CATEGORIES.expense) {
+        if (!categoryMap[cat.name]) {
+          const { data } = await supabase
+            .from("categories")
+            .insert({ name: cat.name, category_type: "expense", color: cat.color, user_id: user.id })
+            .select("id, name")
+            .single();
+          if (data) categoryMap[data.name] = data.id;
+        }
+      }
+    }
+
+    const salaryId = categoryMap["Salary"];
+    const freelanceId = categoryMap["Freelance"];
+    const groceriesId = categoryMap["Groceries"];
+    const rentId = categoryMap["Rent"];
+    const entertainmentId = categoryMap["Entertainment"];
+    const transportId = categoryMap["Transport"];
+    const diningId = categoryMap["Dining"];
+
+    const transactions = [
+      { amount: 3200, type: "income", category_id: salaryId, description: "Monthly salary", date: daysAgo(2) },
+      { amount: 850, type: "income", category_id: freelanceId, description: "Web project", date: daysAgo(5) },
+      { amount: 1200, type: "expense", category_id: rentId, description: "Rent payment", date: daysAgo(3) },
+      { amount: 87.5, type: "expense", category_id: groceriesId, description: "Weekly groceries", date: daysAgo(1) },
+      { amount: 42, type: "expense", category_id: diningId, description: "Dinner out", date: daysAgo(4) },
+      { amount: 15.8, type: "expense", category_id: transportId, description: "Metro pass", date: daysAgo(6) },
+      { amount: 60, type: "expense", category_id: entertainmentId, description: "Movie & drinks", date: daysAgo(8) },
+      { amount: 95, type: "expense", category_id: groceriesId, description: "Supermarket run", date: daysAgo(15) },
+      { amount: 500, type: "income", category_id: freelanceId, description: "Logo design", date: daysAgo(20) },
+      { amount: 3200, type: "income", category_id: salaryId, description: "Monthly salary", date: daysAgo(32) },
+      { amount: 1200, type: "expense", category_id: rentId, description: "Rent payment", date: daysAgo(33) },
+      { amount: 73, type: "expense", category_id: groceriesId, description: "Grocery store", date: daysAgo(38) },
+      { amount: 29, type: "expense", category_id: diningId, description: "Lunch with team", date: daysAgo(45) },
+      { amount: 120, type: "expense", category_id: entertainmentId, description: "Concert tickets", date: daysAgo(55) },
+      { amount: 22.4, type: "expense", category_id: transportId, description: "Taxi rides", date: daysAgo(70) },
+    ].filter((t) => t.category_id);
+
+    const rows = transactions.map((t) => ({ ...t, user_id: user.id }));
+
+    const { error } = await supabase.from("transactions").insert(rows);
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    revalidatePath("/");
+
+    return { success: true, message: `Seeded ${rows.length} transactions` };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred",
+    };
+  }
+}
+
+export async function wipeUserData(): Promise<ActionResult> {
+  if (process.env.NODE_ENV !== "development") {
+    return { success: false, error: "dev only" };
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return { success: false, error: "User not authenticated" };
+    }
+
+    const { error: merchantError } = await supabase
+      .from("merchant_rules")
+      .delete()
+      .eq("user_id", user.id);
+
+    if (merchantError) {
+      return { success: false, error: merchantError.message };
+    }
+
+    const { error: txError } = await supabase
+      .from("transactions")
+      .delete()
+      .eq("user_id", user.id);
+
+    if (txError) {
+      return { success: false, error: txError.message };
+    }
+
+    const { error: catError } = await supabase
+      .from("categories")
+      .delete()
+      .eq("user_id", user.id);
+
+    if (catError) {
+      return { success: false, error: catError.message };
+    }
+
+    revalidatePath("/");
+
+    return { success: true, message: "All data wiped" };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred",
+    };
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
+import { DebugPane } from "@/components/DebugPane";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
       >
         <Navbar />
         {children}
+        {process.env.NODE_ENV === "development" && <DebugPane />}
       </body>
     </html>
   );

--- a/src/components/DebugPane.tsx
+++ b/src/components/DebugPane.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { seedFakeTransactions, wipeUserData } from "@/app/actions/debug-actions";
+
+type Status = { type: "idle" } | { type: "loading" } | { type: "success"; message: string } | { type: "error"; message: string };
+
+export function DebugPane() {
+  const [expanded, setExpanded] = useState(false);
+  const [wipeConfirm, setWipeConfirm] = useState(false);
+  const [status, setStatus] = useState<Status>({ type: "idle" });
+
+  async function handleSeed() {
+    setStatus({ type: "loading" });
+    setWipeConfirm(false);
+    const result = await seedFakeTransactions();
+    if (result.success) {
+      setStatus({ type: "success", message: result.message ?? "Done" });
+    } else {
+      setStatus({ type: "error", message: result.error ?? "Unknown error" });
+    }
+  }
+
+  async function handleWipe() {
+    if (!wipeConfirm) {
+      setWipeConfirm(true);
+      return;
+    }
+    setStatus({ type: "loading" });
+    setWipeConfirm(false);
+    const result = await wipeUserData();
+    if (result.success) {
+      setStatus({ type: "success", message: result.message ?? "Done" });
+    } else {
+      setStatus({ type: "error", message: result.error ?? "Unknown error" });
+    }
+  }
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="fixed bottom-4 right-4 z-40 rounded-full bg-zinc-800 px-3 py-1 text-xs font-mono text-zinc-200 shadow-lg hover:bg-zinc-700"
+      >
+        {"</>"}
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 w-72 rounded-lg border border-zinc-200 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex items-center justify-between border-b border-zinc-100 px-4 py-2 dark:border-zinc-800">
+        <span className="text-xs font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400">
+          Debug
+        </span>
+        <button
+          type="button"
+          onClick={() => { setExpanded(false); setWipeConfirm(false); setStatus({ type: "idle" }); }}
+          className="rounded p-0.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="space-y-2 p-4">
+        <button
+          type="button"
+          onClick={handleSeed}
+          disabled={status.type === "loading"}
+          className="w-full rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-700 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+        >
+          Seed fake data
+        </button>
+
+        {wipeConfirm ? (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleWipe}
+              disabled={status.type === "loading"}
+              className="flex-1 rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Are you sure?
+            </button>
+            <button
+              type="button"
+              onClick={() => setWipeConfirm(false)}
+              className="rounded-md border border-zinc-200 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleWipe}
+            disabled={status.type === "loading"}
+            className="w-full rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-900 dark:bg-red-950 dark:text-red-400 dark:hover:bg-red-900"
+          >
+            Wipe all data
+          </button>
+        )}
+
+        {status.type !== "idle" && (
+          <p className={`text-xs ${
+            status.type === "loading" ? "text-zinc-400" :
+            status.type === "success" ? "text-green-600 dark:text-green-400" :
+            "text-red-600 dark:text-red-400"
+          }`}>
+            {status.type === "loading" ? "Working…" : status.message}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `src/app/actions/debug-actions.ts` with two server actions (`seedFakeTransactions`, `wipeUserData`) guarded by `NODE_ENV !== 'development'` check
- Adds `src/components/DebugPane.tsx` — a fixed bottom-right floating panel with Seed and Wipe buttons, inline confirmation for wipe, and status feedback
- Mounts `<DebugPane />` in `src/app/layout.tsx` conditionally: `{process.env.NODE_ENV === 'development' && <DebugPane />}`, evaluated server-side so zero debug code ships to production

Closes #7

## Test plan

- [ ] `npm run dev` → `</>` pill button appears bottom-right on localhost
- [ ] Click pill → panel expands with Seed and Wipe buttons
- [ ] Click **Seed fake data** → spinner → "Seeded 15 transactions" → dashboard refreshes
- [ ] Click **Wipe all data** → "Are you sure?" inline confirm appears → confirm → "All data wiped" → dashboard clears
- [ ] Click Cancel on wipe confirm → returns to normal button without firing
- [ ] `npm run build && npm start` → `</>` button is **not** present in production