### PR TITLE
Add month navigation to dashboard

### DIFF
--- a/src/app/actions/transaction-actions.ts
+++ b/src/app/actions/transaction-actions.ts
@@ -2,7 +2,8 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
-import { Category, TransactionInsert, TransactionType, TransactionWithCategory } from "@/types/database";
+import { Category, MonthlyTrendItem, TransactionInsert, TransactionType, TransactionWithCategory } from "@/types/database";
+import { parseMonthParam, formatMonthParam } from "@/lib/month";
 
 type RawTransactionRow = Omit<TransactionWithCategory, 'categories'> & {
   categories: Category | Category[] | null;
@@ -43,20 +44,13 @@ interface CategoryBreakdownItem {
   type: TransactionType;
 }
 
-interface MonthlyTrendItem {
-  month: string;
-  income: number;
-  expense: number;
-  net: number;
-}
-
 interface GetDashboardSummaryResult {
   success: boolean;
   data?: DashboardSummaryData;
   error?: string;
 }
 
-export async function getTransactions(): Promise<GetTransactionsResult> {
+export async function getTransactions(month?: string): Promise<GetTransactionsResult> {
   try {
     const supabase = await createClient();
     const {
@@ -67,12 +61,23 @@ export async function getTransactions(): Promise<GetTransactionsResult> {
       return { success: false, error: "User not authenticated" };
     }
 
-    const { data, error } = await supabase
+    let query = supabase
       .from("transactions")
       .select("*, categories(*)")
       .eq("user_id", user.id)
-      .order("date", { ascending: false })
-      .limit(20);
+      .order("date", { ascending: false });
+
+    if (month) {
+      const anchor = parseMonthParam(month);
+      const start = formatMonthParam(anchor) + "-01";
+      const endDate = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0);
+      const end = `${formatMonthParam(anchor)}-${String(endDate.getDate()).padStart(2, "0")}`;
+      query = query.gte("date", start).lte("date", end);
+    } else {
+      query = query.limit(20);
+    }
+
+    const { data, error } = await query;
 
     if (error) {
       return { success: false, error: error.message };
@@ -185,12 +190,12 @@ export async function deleteTransaction(id: string): Promise<ActionResult> {
   }
 }
 
-export async function getDashboardSummary(): Promise<GetDashboardSummaryResult> {
+export async function getDashboardSummary(month?: string): Promise<GetDashboardSummaryResult> {
   try {
-    const now = new Date();
-    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-    const startOfTrendRange = new Date(now.getFullYear(), now.getMonth() - 5, 1);
+    const anchor = parseMonthParam(month);
+    const startOfMonth = new Date(anchor.getFullYear(), anchor.getMonth(), 1);
+    const endOfMonth = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0);
+    const startOfTrendRange = new Date(anchor.getFullYear(), anchor.getMonth() - 5, 1);
 
     const startOfMonthString = formatDateToYYYYMMDD(startOfMonth);
     const endOfMonthString = formatDateToYYYYMMDD(endOfMonth);
@@ -231,6 +236,8 @@ export async function getDashboardSummary(): Promise<GetDashboardSummaryResult> 
       .from("transactions")
       .select("*, categories(*)")
       .eq("user_id", user.id)
+      .gte("date", startOfMonthString)
+      .lte("date", endOfMonthString)
       .order("date", { ascending: false })
       .limit(5);
 
@@ -240,7 +247,7 @@ export async function getDashboardSummary(): Promise<GetDashboardSummaryResult> 
 
     const totals = calculateMonthTotals(monthTransactions || []);
     const categoryBreakdown = buildCategoryBreakdown(monthTransactions || []);
-    const monthlyTrends = buildMonthlyTrends(trendTransactions || [], now);
+    const monthlyTrends = buildMonthlyTrends(trendTransactions || [], anchor);
 
     const normalizedRecentTransactions = (recentTransactions || []).map((t: RawTransactionRow) => ({
       ...t,
@@ -360,6 +367,7 @@ function buildMonthlyTrends(
     const entry = trendMap.get(key) || { income: 0, expense: 0 };
     return {
       month: trendLabels[index],
+      monthKey: key,
       income: entry.income,
       expense: entry.expense,
       net: entry.income - entry.expense,

--- a/src/app/actions/transaction-actions.ts
+++ b/src/app/actions/transaction-actions.ts
@@ -69,10 +69,11 @@ export async function getTransactions(month?: string): Promise<GetTransactionsRe
 
     if (month) {
       const anchor = parseMonthParam(month);
-      const start = formatMonthParam(anchor) + "-01";
+      const prefix = formatMonthParam(anchor);
       const endDate = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0);
-      const end = `${formatMonthParam(anchor)}-${String(endDate.getDate()).padStart(2, "0")}`;
-      query = query.gte("date", start).lte("date", end);
+      const start = `${prefix}-01`;
+      const end = `${prefix}-${String(endDate.getDate()).padStart(2, "0")}`;
+      query = query.gte("date", start).lte("date", end).limit(200);
     } else {
       query = query.limit(20);
     }

--- a/src/app/actions/transaction-actions.ts
+++ b/src/app/actions/transaction-actions.ts
@@ -196,11 +196,16 @@ export async function getDashboardSummary(month?: string): Promise<GetDashboardS
     const anchor = parseMonthParam(month);
     const startOfMonth = new Date(anchor.getFullYear(), anchor.getMonth(), 1);
     const endOfMonth = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0);
-    const startOfTrendRange = new Date(anchor.getFullYear(), anchor.getMonth() - 5, 1);
+
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), 1);
+    const startOfTrendRange = new Date(today.getFullYear(), today.getMonth() - 5, 1);
+    const endOfTrendRange = new Date(today.getFullYear(), today.getMonth() + 1, 0);
 
     const startOfMonthString = formatDateToYYYYMMDD(startOfMonth);
     const endOfMonthString = formatDateToYYYYMMDD(endOfMonth);
     const startOfTrendRangeString = formatDateToYYYYMMDD(startOfTrendRange);
+    const endOfTrendRangeString = formatDateToYYYYMMDD(endOfTrendRange);
 
     const supabase = await createClient();
     const {
@@ -227,7 +232,7 @@ export async function getDashboardSummary(month?: string): Promise<GetDashboardS
       .select("amount, type, date")
       .eq("user_id", user.id)
       .gte("date", startOfTrendRangeString)
-      .lte("date", endOfMonthString);
+      .lte("date", endOfTrendRangeString);
 
     if (trendError) {
       return { success: false, error: trendError.message };
@@ -248,7 +253,7 @@ export async function getDashboardSummary(month?: string): Promise<GetDashboardS
 
     const totals = calculateMonthTotals(monthTransactions || []);
     const categoryBreakdown = buildCategoryBreakdown(monthTransactions || []);
-    const monthlyTrends = buildMonthlyTrends(trendTransactions || [], anchor);
+    const monthlyTrends = buildMonthlyTrends(trendTransactions || [], today);
 
     const normalizedRecentTransactions = (recentTransactions || []).map((t: RawTransactionRow) => ({
       ...t,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,7 @@
-import { getTransactions } from "@/app/actions/transaction-actions";
-import { getCategories } from "@/app/actions/category-actions";
+import { Suspense } from "react";
 import { parseMonthParam, formatMonthParam, formatMonthHeading } from "@/lib/month";
-import { AddTransactionButton } from "@/components/AddTransactionButton";
-import { ImportTransactionsButton } from "@/components/ImportTransactionsButton";
-import { DashboardSummary } from "@/components/DashboardSummary";
 import { MonthNav } from "@/components/MonthNav";
-import { TransactionList } from "@/components/TransactionList";
+import { DashboardContent, DashboardSkeleton } from "@/components/DashboardContent";
 
 export default async function Home({
   searchParams,
@@ -15,14 +11,6 @@ export default async function Home({
   const { month: monthParam } = await searchParams;
   const selectedMonth = parseMonthParam(monthParam);
   const monthKey = formatMonthParam(selectedMonth);
-
-  const [transactionResult, categoryResult] = await Promise.all([
-    getTransactions(monthKey),
-    getCategories(),
-  ]);
-
-  const transactions = transactionResult.success ? transactionResult.data || [] : [];
-  const categories = categoryResult.success ? categoryResult.data || [] : [];
 
   return (
     <div className="min-h-screen bg-zinc-50 font-sans dark:bg-black">
@@ -35,30 +23,9 @@ export default async function Home({
           </MonthNav>
         </header>
 
-        <DashboardSummary month={monthKey} />
-
-        <section>
-          <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Transactions
-            </h2>
-            <div className="flex gap-2">
-              <ImportTransactionsButton />
-              <AddTransactionButton />
-            </div>
-          </div>
-
-          {transactionResult.success ? (
-            <TransactionList
-              transactions={transactions}
-              categories={categories}
-            />
-          ) : (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
-              <p>Failed to load transactions: {transactionResult.error}</p>
-            </div>
-          )}
-        </section>
+        <Suspense key={monthKey} fallback={<DashboardSkeleton />}>
+          <DashboardContent month={monthKey} />
+        </Suspense>
       </main>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,23 @@
 import { getTransactions } from "@/app/actions/transaction-actions";
 import { getCategories } from "@/app/actions/category-actions";
+import { parseMonthParam, formatMonthParam, formatMonthHeading } from "@/lib/month";
 import { AddTransactionButton } from "@/components/AddTransactionButton";
 import { ImportTransactionsButton } from "@/components/ImportTransactionsButton";
 import { DashboardSummary } from "@/components/DashboardSummary";
+import { MonthNav } from "@/components/MonthNav";
 import { TransactionList } from "@/components/TransactionList";
 
-export default async function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ month?: string }>;
+}) {
+  const { month: monthParam } = await searchParams;
+  const selectedMonth = parseMonthParam(monthParam);
+  const monthKey = formatMonthParam(selectedMonth);
+
   const [transactionResult, categoryResult] = await Promise.all([
-    getTransactions(),
+    getTransactions(monthKey),
     getCategories(),
   ]);
 
@@ -17,13 +27,14 @@ export default async function Home() {
   return (
     <div className="min-h-screen bg-zinc-50 font-sans dark:bg-black">
       <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-        <header className="mb-8">
+        <header className="mb-8 flex items-center gap-3">
+          <MonthNav currentMonth={monthKey} />
           <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-            {new Date().toLocaleDateString("en-US", { month: "long", year: "numeric" })}
+            {formatMonthHeading(selectedMonth)}
           </h1>
         </header>
 
-        <DashboardSummary />
+        <DashboardSummary month={monthKey} />
 
         <section>
           <div className="mb-4 flex items-center justify-between">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,11 +27,12 @@ export default async function Home({
   return (
     <div className="min-h-screen bg-zinc-50 font-sans dark:bg-black">
       <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-        <header className="mb-8 flex items-center gap-3">
-          <MonthNav currentMonth={monthKey} />
-          <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-            {formatMonthHeading(selectedMonth)}
-          </h1>
+        <header className="mb-8">
+          <MonthNav currentMonth={monthKey}>
+            <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+              {formatMonthHeading(selectedMonth)}
+            </h1>
+          </MonthNav>
         </header>
 
         <DashboardSummary month={monthKey} />

--- a/src/components/BalanceTrendsChart.tsx
+++ b/src/components/BalanceTrendsChart.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { MonthlyTrendItem } from "@/types/database";
+
+interface BalanceTrendsChartProps {
+  trends: MonthlyTrendItem[];
+  selectedMonth: string;
+}
+
+export function BalanceTrendsChart({ trends, selectedMonth }: BalanceTrendsChartProps) {
+  const router = useRouter();
+  const trendScale = Math.max(...trends.map((t) => Math.abs(t.net)), 1);
+
+  return (
+    <div className="mt-4 grid gap-3 sm:grid-cols-6">
+      {trends.map((trend) => {
+        const isSelected = trend.monthKey === selectedMonth;
+        const height = Math.round((Math.abs(trend.net) / trendScale) * 64);
+        return (
+          <button
+            key={trend.monthKey}
+            onClick={() => router.push(`/?month=${trend.monthKey}`)}
+            className="flex cursor-pointer flex-col items-center gap-2"
+          >
+            {trend.net === 0 ? (
+              <div className="flex h-20 items-end">
+                <div className="h-px w-6 bg-zinc-300 dark:bg-zinc-700" />
+              </div>
+            ) : (
+              <div className="flex h-20 items-end">
+                <div
+                  className={
+                    trend.net >= 0
+                      ? `w-6 rounded-md bg-green-500 ${isSelected ? "opacity-100" : "opacity-50"}`
+                      : `w-6 rounded-md bg-red-500 ${isSelected ? "opacity-100" : "opacity-50"}`
+                  }
+                  style={{ height }}
+                />
+              </div>
+            )}
+            <span
+              className={`text-xs ${
+                isSelected
+                  ? "font-bold text-zinc-900 dark:text-zinc-50"
+                  : "text-zinc-500 dark:text-zinc-400"
+              }`}
+            >
+              {trend.month}
+            </span>
+            {trend.net === 0 ? (
+              <span className="text-xs text-zinc-500 dark:text-zinc-400">—</span>
+            ) : (
+              <span
+                className={`text-xs ${
+                  trend.net >= 0
+                    ? "text-green-600 dark:text-green-400"
+                    : "text-red-600 dark:text-red-400"
+                }`}
+              >
+                {formatCurrency(trend.net)}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+}

--- a/src/components/BalanceTrendsChart.tsx
+++ b/src/components/BalanceTrendsChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { formatCurrency } from "@/lib/format";
 import type { MonthlyTrendItem } from "@/types/database";
 
 interface BalanceTrendsChartProps {
@@ -9,7 +10,6 @@ interface BalanceTrendsChartProps {
 }
 
 export function BalanceTrendsChart({ trends, selectedMonth }: BalanceTrendsChartProps) {
-  const router = useRouter();
   const trendScale = Math.max(...trends.map((t) => Math.abs(t.net)), 1);
 
   return (
@@ -18,9 +18,10 @@ export function BalanceTrendsChart({ trends, selectedMonth }: BalanceTrendsChart
         const isSelected = trend.monthKey === selectedMonth;
         const height = Math.round((Math.abs(trend.net) / trendScale) * 64);
         return (
-          <button
+          <Link
             key={trend.monthKey}
-            onClick={() => router.push(`/?month=${trend.monthKey}`)}
+            href={`/?month=${trend.monthKey}`}
+            aria-label={`View ${trend.month}`}
             className="flex cursor-pointer flex-col items-center gap-2"
           >
             {trend.net === 0 ? (
@@ -61,17 +62,9 @@ export function BalanceTrendsChart({ trends, selectedMonth }: BalanceTrendsChart
                 {formatCurrency(trend.net)}
               </span>
             )}
-          </button>
+          </Link>
         );
       })}
     </div>
   );
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 2,
-  }).format(value);
 }

--- a/src/components/DashboardContent.tsx
+++ b/src/components/DashboardContent.tsx
@@ -1,0 +1,142 @@
+import { getTransactions } from "@/app/actions/transaction-actions";
+import { getCategories } from "@/app/actions/category-actions";
+import { AddTransactionButton } from "@/components/AddTransactionButton";
+import { ImportTransactionsButton } from "@/components/ImportTransactionsButton";
+import { DashboardSummary } from "@/components/DashboardSummary";
+import { TransactionList } from "@/components/TransactionList";
+
+export async function DashboardContent({ month }: { month: string }) {
+  const [transactionResult, categoryResult] = await Promise.all([
+    getTransactions(month),
+    getCategories(),
+  ]);
+
+  const transactions = transactionResult.success ? transactionResult.data || [] : [];
+  const categories = categoryResult.success ? categoryResult.data || [] : [];
+
+  return (
+    <>
+      <DashboardSummary month={month} />
+
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">Transactions</h2>
+          <div className="flex gap-2">
+            <ImportTransactionsButton />
+            <AddTransactionButton />
+          </div>
+        </div>
+
+        {transactionResult.success ? (
+          <TransactionList transactions={transactions} categories={categories} />
+        ) : (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+            <p>Failed to load transactions: {transactionResult.error}</p>
+          </div>
+        )}
+      </section>
+    </>
+  );
+}
+
+export function DashboardSkeleton() {
+  return (
+    <>
+      <section className="mb-8">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="flex items-center justify-between">
+                <div className="h-4 w-14 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="h-5 w-5 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800" />
+              </div>
+              <div className="mt-2 h-8 w-28 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-3">
+          <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 lg:col-span-2">
+            <div className="h-4 w-36 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              {[0, 1].map((col) => (
+                <div key={col} className="space-y-3">
+                  {[0, 1, 2].map((row) => (
+                    <div key={row} className="space-y-1">
+                      <div className="flex justify-between">
+                        <div className="h-4 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                        <div className="h-4 w-12 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                      </div>
+                      <div className="h-2 w-full animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800" />
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="h-4 w-28 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+            <div className="mt-4 space-y-4">
+              <div>
+                <div className="h-3 w-16 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="mt-1 h-7 w-16 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+              </div>
+              <div>
+                <div className="h-3 w-20 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="mt-1 h-4 w-28 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="mt-1 h-4 w-16 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex items-center justify-between">
+            <div className="h-4 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+            <div className="h-3 w-32 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-6">
+            {[32, 48, 24, 56, 40, 36].map((h, i) => (
+              <div key={i} className="flex flex-col items-center gap-2">
+                <div className="flex h-20 items-end">
+                  <div className="w-6 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" style={{ height: h }} />
+                </div>
+                <div className="h-3 w-12 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="h-3 w-10 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <div className="h-7 w-28 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+          <div className="flex gap-2">
+            <div className="h-9 w-24 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+            <div className="h-9 w-36 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+          </div>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-800/50">
+            <div className="grid grid-cols-4 gap-8">
+              {[0, 1, 2, 3].map((i) => (
+                <div key={i} className="h-4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+              ))}
+            </div>
+          </div>
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="border-b border-zinc-100 px-4 py-3 last:border-b-0 dark:border-zinc-800">
+              <div className="grid grid-cols-4 gap-8">
+                <div className="h-4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="h-4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="h-4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="h-4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/components/DashboardSummary.tsx
+++ b/src/components/DashboardSummary.tsx
@@ -1,9 +1,14 @@
 import { getDashboardSummary } from "@/app/actions/transaction-actions";
+import { BalanceTrendsChart } from "@/components/BalanceTrendsChart";
 import { ArrowDownRight, ArrowUpRight, Wallet } from "lucide-react";
 import type { ReactNode } from "react";
 
-export async function DashboardSummary() {
-  const result = await getDashboardSummary();
+interface DashboardSummaryProps {
+  month: string;
+}
+
+export async function DashboardSummary({ month }: DashboardSummaryProps) {
+  const result = await getDashboardSummary(month);
 
   if (!result.success || !result.data) {
     return (
@@ -23,10 +28,6 @@ export async function DashboardSummary() {
 
   const incomeCategories = categoryBreakdown.filter((item) => item.type === "income");
   const expenseCategories = categoryBreakdown.filter((item) => item.type === "expense");
-  const trendScale = Math.max(
-    ...monthlyTrends.map((trend) => Math.abs(trend.net)),
-    1
-  );
 
   return (
     <section className="mb-8">
@@ -99,47 +100,7 @@ export async function DashboardSummary() {
             Net income vs expenses
           </span>
         </div>
-        <div className="mt-4 grid gap-3 sm:grid-cols-6">
-          {monthlyTrends.map((trend) => {
-            const height = Math.round((Math.abs(trend.net) / trendScale) * 64);
-            return (
-              <div key={trend.month} className="flex flex-col items-center gap-2">
-                {trend.net === 0 ? (
-                  <div className="flex h-20 items-end">
-                    <div className="h-px w-6 bg-zinc-300 dark:bg-zinc-700" />
-                  </div>
-                ) : (
-                  <div className="flex h-20 items-end">
-                    <div
-                      className={
-                        trend.net >= 0
-                          ? "w-6 rounded-md bg-green-500/70"
-                          : "w-6 rounded-md bg-red-500/70"
-                      }
-                      style={{ height }}
-                    />
-                  </div>
-                )}
-                <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                  {trend.month}
-                </span>
-                {trend.net === 0 ? (
-                  <span className="text-xs text-zinc-500 dark:text-zinc-400">—</span>
-                ) : (
-                  <span
-                    className={
-                      trend.net >= 0
-                        ? "text-xs text-green-600 dark:text-green-400"
-                        : "text-xs text-red-600 dark:text-red-400"
-                    }
-                  >
-                    {formatCurrency(trend.net)}
-                  </span>
-                )}
-              </div>
-            );
-          })}
-        </div>
+        <BalanceTrendsChart trends={monthlyTrends} selectedMonth={month} />
       </div>
     </section>
   );

--- a/src/components/DashboardSummary.tsx
+++ b/src/components/DashboardSummary.tsx
@@ -1,5 +1,6 @@
 import { getDashboardSummary } from "@/app/actions/transaction-actions";
 import { BalanceTrendsChart } from "@/components/BalanceTrendsChart";
+import { formatCurrency } from "@/lib/format";
 import { ArrowDownRight, ArrowUpRight, Wallet } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -181,10 +182,3 @@ function CategoryBreakdownList({ title, items }: CategoryBreakdownListProps) {
   );
 }
 
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 2,
-  }).format(value);
-}

--- a/src/components/MonthNav.tsx
+++ b/src/components/MonthNav.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+interface MonthNavProps {
+  currentMonth: string;
+}
+
+export function MonthNav({ currentMonth }: MonthNavProps) {
+  const router = useRouter();
+
+  function navigate(direction: -1 | 1) {
+    const [year, month] = currentMonth.split("-").map(Number);
+    const date = new Date(year, month - 1 + direction, 1);
+    const newKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+    router.push(`/?month=${newKey}`);
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        onClick={() => navigate(-1)}
+        className="rounded p-1 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+        aria-label="Previous month"
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </button>
+      <button
+        onClick={() => navigate(1)}
+        className="rounded p-1 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+        aria-label="Next month"
+      >
+        <ChevronRight className="h-5 w-5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/MonthNav.tsx
+++ b/src/components/MonthNav.tsx
@@ -1,17 +1,22 @@
-"use client";
-
 import Link from "next/link";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { parseMonthParam, formatMonthParam } from "@/lib/month";
+import type { ReactNode } from "react";
 
 interface MonthNavProps {
   currentMonth: string;
+  children?: ReactNode;
 }
 
-export function MonthNav({ currentMonth }: MonthNavProps) {
+export function MonthNav({ currentMonth, children }: MonthNavProps) {
   const current = parseMonthParam(currentMonth);
   const prev = new Date(current.getFullYear(), current.getMonth() - 1, 1);
   const next = new Date(current.getFullYear(), current.getMonth() + 1, 1);
+
+  const now = new Date();
+  const isCurrentOrFuture =
+    current.getFullYear() > now.getFullYear() ||
+    (current.getFullYear() === now.getFullYear() && current.getMonth() >= now.getMonth());
 
   const linkClass =
     "rounded p-1 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50";
@@ -21,9 +26,12 @@ export function MonthNav({ currentMonth }: MonthNavProps) {
       <Link href={`/?month=${formatMonthParam(prev)}`} aria-label="Previous month" className={linkClass}>
         <ChevronLeft className="h-5 w-5" />
       </Link>
-      <Link href={`/?month=${formatMonthParam(next)}`} aria-label="Next month" className={linkClass}>
-        <ChevronRight className="h-5 w-5" />
-      </Link>
+      {children}
+      {!isCurrentOrFuture && (
+        <Link href={`/?month=${formatMonthParam(next)}`} aria-label="Next month" className={linkClass}>
+          <ChevronRight className="h-5 w-5" />
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/components/MonthNav.tsx
+++ b/src/components/MonthNav.tsx
@@ -1,38 +1,29 @@
 "use client";
 
+import Link from "next/link";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { parseMonthParam, formatMonthParam } from "@/lib/month";
 
 interface MonthNavProps {
   currentMonth: string;
 }
 
 export function MonthNav({ currentMonth }: MonthNavProps) {
-  const router = useRouter();
+  const current = parseMonthParam(currentMonth);
+  const prev = new Date(current.getFullYear(), current.getMonth() - 1, 1);
+  const next = new Date(current.getFullYear(), current.getMonth() + 1, 1);
 
-  function navigate(direction: -1 | 1) {
-    const [year, month] = currentMonth.split("-").map(Number);
-    const date = new Date(year, month - 1 + direction, 1);
-    const newKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
-    router.push(`/?month=${newKey}`);
-  }
+  const linkClass =
+    "rounded p-1 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50";
 
   return (
     <div className="flex items-center gap-1">
-      <button
-        onClick={() => navigate(-1)}
-        className="rounded p-1 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
-        aria-label="Previous month"
-      >
+      <Link href={`/?month=${formatMonthParam(prev)}`} aria-label="Previous month" className={linkClass}>
         <ChevronLeft className="h-5 w-5" />
-      </button>
-      <button
-        onClick={() => navigate(1)}
-        className="rounded p-1 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
-        aria-label="Next month"
-      >
+      </Link>
+      <Link href={`/?month=${formatMonthParam(next)}`} aria-label="Next month" className={linkClass}>
         <ChevronRight className="h-5 w-5" />
-      </button>
+      </Link>
     </div>
   );
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,7 @@
+export function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+}

--- a/src/lib/month.ts
+++ b/src/lib/month.ts
@@ -1,0 +1,21 @@
+export function parseMonthParam(param?: string): Date {
+  if (param && /^\d{4}-\d{2}$/.test(param)) {
+    const [year, month] = param.split("-").map(Number);
+    const date = new Date(year, month - 1, 1);
+    if (!isNaN(date.getTime())) {
+      return date;
+    }
+  }
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), 1);
+}
+
+export function formatMonthParam(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+export function formatMonthHeading(date: Date): string {
+  return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}

--- a/src/lib/month.ts
+++ b/src/lib/month.ts
@@ -1,9 +1,8 @@
 export function parseMonthParam(param?: string): Date {
   if (param && /^\d{4}-\d{2}$/.test(param)) {
     const [year, month] = param.split("-").map(Number);
-    const date = new Date(year, month - 1, 1);
-    if (!isNaN(date.getTime())) {
-      return date;
+    if (month >= 1 && month <= 12) {
+      return new Date(year, month - 1, 1);
     }
   }
   const now = new Date();

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -52,3 +52,11 @@ export interface TransactionWithCategory extends Omit<Transaction, 'category'> {
     categories: Category | null;
 }
 
+export interface MonthlyTrendItem {
+  month: string;     // "Apr 2026" — display label
+  monthKey: string;  // "2026-04"  — navigation key
+  income: number;
+  expense: number;
+  net: number;
+}
+


### PR DESCRIPTION
## Summary

- Adds `<` / `>` chevron buttons in the page header to navigate between months
- Clicking a bar in the Balance Trends chart navigates to that month, with the selected bar highlighted and others dimmed
- All dashboard sections (summary cards, category breakdown, monthly insights, transactions list) scope to the selected month
- Month state is stored in `?month=YYYY-MM` URL param — full server re-render on each navigation, no client state

## What changed

**New files:**
- `src/lib/month.ts` — pure helpers: `parseMonthParam`, `formatMonthParam`, `formatMonthHeading`
- `src/components/MonthNav.tsx` — client component with ChevronLeft/ChevronRight buttons
- `src/components/BalanceTrendsChart.tsx` — client component extracted from `DashboardSummary`; handles bar click → `router.push`

**Modified files:**
- `src/types/database.ts` — adds `MonthlyTrendItem` (shared between server action and client chart)
- `src/app/actions/transaction-actions.ts` — `getTransactions(month?)` and `getDashboardSummary(month?)` accept optional month param; `buildMonthlyTrends` now includes `monthKey`; removes local `MonthlyTrendItem` in favour of shared type
- `src/components/DashboardSummary.tsx` — accepts `month: string` prop, uses `<BalanceTrendsChart />`
- `src/app/page.tsx` — parses `searchParams.month`, renders `<MonthNav />` in header, passes `monthKey` to all data fetchers

## Conservative choices

- Invalid `?month=foo` params silently fall back to current month (via `parseMonthParam`)
- `recentTransactions` in `getDashboardSummary` is now also date-filtered to the selected month (consistent with everything else on the page)

## Test plan

- [x] `<` button changes heading to previous month; all sections update
- [x] `>` button changes heading to next month; all sections update
- [x] Clicking a Balance Trends bar navigates to that month; bar is highlighted; heading + data update
- [x] `?month=2026-02` directly in URL shows February data
- [x] `?month=foo` (invalid) falls back to current month without crash
- [x] `npm run build && npm run lint` pass cleanly

Closes #10