### PR TITLE
Add Playwright E2E tests for core user flows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npx playwright test
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-artifacts
+          path: |
+            playwright-report/
+            test-results/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       - run: npx playwright install --with-deps chromium
       - run: npx playwright test
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+e2e/.auth/
+playwright-report/
+test-results/
 
 # next.js
 /.next/

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -16,4 +16,5 @@ test('can sign in with email and password', async ({ page }) => {
   await page.getByRole('button', { name: 'Sign in', exact: true }).click();
 
   await expect(page).toHaveURL('/');
+  await expect(page.getByRole('button', { name: 'Add Transaction' })).toBeVisible();
 });

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('unauthenticated visit to / redirects to /login', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test('can sign in with email and password', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByText('Sign in with email').click();
+  await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL!);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+
+  await expect(page).toHaveURL('/');
+});

--- a/e2e/credentials.ts
+++ b/e2e/credentials.ts
@@ -1,4 +1,0 @@
-export const TEST_USER = {
-    email: 'dev@budget-buddy.local',
-    password: 'test1234',
-};

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('dashboard renders summary cards', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByText('Income').first()).toBeVisible();
+  await expect(page.getByText('Expenses').first()).toBeVisible();
+  await expect(page.getByText('Saved This Month')).toBeVisible();
+});
+
+test('Add Transaction button is visible', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: 'Add Transaction' })).toBeVisible();
+});
+
+test('Transactions section heading is visible', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Transactions' })).toBeVisible();
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,18 +1,20 @@
 import { chromium } from '@playwright/test';
 import * as path from 'path';
 
+const BASE_URL = 'http://localhost:3000';
+
 export default async function globalSetup() {
   const browser = await chromium.launch({ channel: 'chrome' });
   const page = await browser.newPage();
 
-  await page.goto('http://localhost:3000/login');
+  await page.goto(`${BASE_URL}/login`);
 
   await page.getByText('Sign in with email').click();
   await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL!);
   await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD!);
   await page.getByRole('button', { name: 'Sign in', exact: true }).click();
 
-  await page.waitForURL('http://localhost:3000/');
+  await page.waitForURL(`${BASE_URL}/`);
 
   await page.context().storageState({
     path: path.join(process.cwd(), 'e2e/.auth/user.json'),

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,22 @@
+import { chromium } from '@playwright/test';
+import * as path from 'path';
+
+export default async function globalSetup() {
+  const browser = await chromium.launch({ channel: 'chrome' });
+  const page = await browser.newPage();
+
+  await page.goto('http://localhost:3000/login');
+
+  await page.getByText('Sign in with email').click();
+  await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL!);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+
+  await page.waitForURL('http://localhost:3000/');
+
+  await page.context().storageState({
+    path: path.join(process.cwd(), 'e2e/.auth/user.json'),
+  });
+
+  await browser.close();
+}

--- a/e2e/helpers/transactions.ts
+++ b/e2e/helpers/transactions.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 
 export async function addTransaction(page: Page): Promise<string> {
@@ -12,6 +12,8 @@ export async function addTransaction(page: Page): Promise<string> {
   await page.getByText('+ New Category').click();
   await page.getByPlaceholder('Enter new category name').fill(categoryName);
   await page.getByRole('button', { name: 'Create' }).click();
+  // Wait for the inline category form to close before continuing
+  await expect(page.getByPlaceholder('Enter new category name')).not.toBeVisible();
 
   await page.getByLabel('Description (Optional)').fill(marker);
 

--- a/e2e/helpers/transactions.ts
+++ b/e2e/helpers/transactions.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+import { randomUUID } from 'crypto';
+
+export async function addTransaction(page: Page): Promise<string> {
+  const marker = 'e2e-' + randomUUID();
+  const categoryName = 'e2e-cat-' + randomUUID().slice(0, 8);
+
+  await page.getByRole('button', { name: 'Add Transaction' }).click();
+
+  await page.getByLabel('Amount').fill('9.99');
+
+  await page.getByText('+ New Category').click();
+  await page.getByPlaceholder('Enter new category name').fill(categoryName);
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await page.getByLabel('Description (Optional)').fill(marker);
+
+  await page.locator('form').getByRole('button', { name: 'Add Transaction' }).click();
+
+  return marker;
+}

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { addTransaction } from './helpers/transactions';
+
+test('can add a transaction', async ({ page }) => {
+  await page.goto('/');
+
+  const marker = await addTransaction(page);
+
+  // Modal closes after 1.5s success delay; the modal title heading is only in the modal
+  await expect(page.getByRole('heading', { name: 'Add Transaction' })).not.toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(marker)).toBeVisible();
+});
+
+test('can delete a transaction', async ({ page }) => {
+  await page.goto('/');
+
+  const marker = await addTransaction(page);
+
+  await expect(page.getByRole('heading', { name: 'Add Transaction' })).not.toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(marker)).toBeVisible();
+
+  page.on('dialog', (dialog) => dialog.accept());
+
+  const row = page.locator('tr', { hasText: marker });
+  await row.getByTitle('Delete transaction').click();
+
+  await expect(page.getByText(marker)).not.toBeVisible();
+});

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -19,10 +19,10 @@ test('can delete a transaction', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Add Transaction' })).not.toBeVisible({ timeout: 5000 });
   await expect(page.getByText(marker)).toBeVisible();
 
+  // Register before the click that triggers globalThis.confirm()
   page.on('dialog', (dialog) => dialog.accept());
 
-  const row = page.locator('tr', { hasText: marker });
-  await row.getByTitle('Delete transaction').click();
+  await page.locator('tr', { hasText: marker }).getByTitle('Delete transaction').click();
 
   await expect(page.getByText(marker)).not.toBeVisible();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/dotenv": "^6.1.1",
         "@types/node": "^20",
@@ -1674,6 +1675,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -6013,6 +6030,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
@@ -18,6 +19,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/dotenv": "^6.1.1",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
+
+export default defineConfig({
+  testDir: './e2e',
+  globalSetup: './e2e/global-setup.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: 'http://localhost:3000',
+    storageState: 'e2e/.auth/user.json',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/scripts/seed_categories.ts
+++ b/scripts/seed_categories.ts
@@ -82,8 +82,6 @@ const GLOBAL_RULES = [
     { pattern: 'target', category: 'Shopping' },
 ];
 
-import { TEST_USER } from '../e2e/credentials';
-
 async function seed() {
     console.log('Seeding categories...');
 
@@ -100,16 +98,24 @@ async function seed() {
             console.log('Admin API error (likely missing Service Role Key):', adminError.message);
         }
 
-        console.log(`Attempting to login as ${TEST_USER.email} instead...`);
+        const email = process.env.TEST_USER_EMAIL;
+        const password = process.env.TEST_USER_PASSWORD;
+
+        if (!email || !password) {
+            console.error('No admin access and TEST_USER_EMAIL/TEST_USER_PASSWORD not set in .env.local');
+            return;
+        }
+
+        console.log(`Attempting to login as ${email} instead...`);
 
         const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email,
+            password,
         });
 
         if (authError) {
             console.error('Login failed:', authError.message);
-            console.error('Make sure your credentials in e2e/credentials.ts match a user in your Supabase project.');
+            console.error('Make sure TEST_USER_EMAIL and TEST_USER_PASSWORD in .env.local match a user in your Supabase project.');
             return;
         }
 


### PR DESCRIPTION
## Summary

- Adds `@playwright/test` and a `test:e2e` npm script
- `playwright.config.ts`: serial workers, shared auth state via `globalSetup`, `channel: 'chrome'` (uses system Chrome), `webServer` auto-start, dotenv from `.env.local`
- `e2e/global-setup.ts`: logs in once, saves auth cookies to `e2e/.auth/user.json` for all tests
- `e2e/auth.spec.ts`: unauthenticated redirect to `/login`; email sign-in flow
- `e2e/dashboard.spec.ts`: summary cards render; Add Transaction button; Transactions heading
- `e2e/transactions.spec.ts` + `e2e/helpers/transactions.ts`: add transaction via inline category creation; delete transaction via `confirm()` dialog
- `.github/workflows/e2e.yml`: runs on push to master and all PRs; uploads trace artifacts on failure

Closes #13

## Notes

- Uses `channel: 'chrome'` instead of Playwright's bundled Chromium because Ubuntu 26.04 is not yet supported by Playwright 1.59.1's downloader. CI installs `--with-deps chromium` which will use the installed Chrome.
- UUID markers make assertions deterministic across runs against the shared Supabase test user — verified by running `npm run test:e2e` twice consecutively (7/7 both times).

## Test plan

- [x] `npm run test:e2e` passes locally (7/7)
- [x] Second run without cleanup still passes (marker isolation confirmed)
- [ ] GitHub Actions secrets set (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `TEST_USER_EMAIL`, `TEST_USER_PASSWORD`) — required for CI to pass