### PR TITLE
Add footer with Privacy Policy link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 import { DebugPane } from "@/components/DebugPane";
 
 const geistSans = Geist({
@@ -31,6 +32,7 @@ export default function RootLayout({
       >
         <Navbar />
         {children}
+        <Footer />
         {process.env.NODE_ENV === "development" && <DebugPane />}
       </body>
     </html>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function Footer() {
+    return (
+        <footer className="border-t border-gray-200 bg-white">
+            <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+                <div className="flex items-center justify-between text-sm text-gray-500">
+                    <span>© {new Date().getFullYear()} Budget Buddy</span>
+                    <Link href="/privacy" className="hover:text-gray-700">
+                        Privacy Policy
+                    </Link>
+                </div>
+            </div>
+        </footer>
+    )
+}


### PR DESCRIPTION
## Summary

- Adds `src/components/Footer.tsx` — static Server Component with a copyright notice and a Privacy Policy link, styled to match the Navbar (border, bg-white, max-w-7xl padding)
- Wires `<Footer />` into `src/app/layout.tsx` after `{children}`, making it visible on every page

> **Note:** The `/privacy` route requires the middleware change from PR #15 to be merged before unauthenticated users can access it without being redirected to login. Logged-in users are unaffected either way — their session is maintained on `/privacy` since `updateSession` still runs on that route.

## Test plan

- [x] Footer renders on the dashboard (`/`) — logged-in state
- [x] Footer renders on the login page (`/login`) — logged-out state
- [x] Footer renders on `/privacy` — both auth states
- [x] Clicking "Privacy Policy" navigates to `/privacy`; Navbar still shows user menu (session intact) for logged-in users