### PR TITLE
Add Terms of Service page

### DIFF
--- a/e2e/static-pages.spec.ts
+++ b/e2e/static-pages.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('/privacy is reachable without auth', async ({ page }) => {
+  await page.goto('/privacy');
+  await expect(page).toHaveURL('/privacy');
+  await expect(page.getByRole('heading', { name: 'Privacy Policy' })).toBeVisible();
+});
+
+test('/terms is reachable without auth', async ({ page }) => {
+  await page.goto('/terms');
+  await expect(page).toHaveURL('/terms');
+  await expect(page.getByRole('heading', { name: 'Terms of Service' })).toBeVisible();
+});

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,47 @@
+export default function TermsPage() {
+    return (
+        <div className="min-h-screen bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-2xl space-y-8">
+                <div>
+                    <h1 className="text-3xl font-bold tracking-tight text-gray-900">Terms of Service</h1>
+                    <p className="mt-2 text-sm text-gray-500">Last updated: April 2025</p>
+                </div>
+
+                <section className="space-y-3">
+                    <h2 className="text-xl font-semibold text-gray-900">Provided As-Is</h2>
+                    <p className="text-gray-700">
+                        Budget Buddy is a personal finance tracking tool provided as-is, without warranty of any kind,
+                        express or implied. We make no guarantees about accuracy, availability, or fitness for any
+                        particular purpose.
+                    </p>
+                </section>
+
+                <section className="space-y-3">
+                    <h2 className="text-xl font-semibold text-gray-900">Your Data</h2>
+                    <p className="text-gray-700">
+                        You are solely responsible for the data you enter into the app. We do not verify the accuracy
+                        of any financial information you provide, and we are not liable for any decisions made based
+                        on data stored in Budget Buddy.
+                    </p>
+                </section>
+
+                <section className="space-y-3">
+                    <h2 className="text-xl font-semibold text-gray-900">No Warranty or Liability</h2>
+                    <p className="text-gray-700">
+                        To the fullest extent permitted by applicable law, we disclaim all warranties and shall not
+                        be liable for any direct, indirect, incidental, or consequential damages arising from your
+                        use of this service.
+                    </p>
+                </section>
+
+                <section className="space-y-3">
+                    <h2 className="text-xl font-semibold text-gray-900">Termination</h2>
+                    <p className="text-gray-700">
+                        We reserve the right to suspend or terminate your access to Budget Buddy at any time, for
+                        any reason, without prior notice.
+                    </p>
+                </section>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,9 +6,14 @@ export default function Footer() {
             <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
                 <div className="flex items-center justify-between text-sm text-gray-500">
                     <span>© {new Date().getFullYear()} Budget Buddy</span>
-                    <Link href="/privacy" className="hover:text-gray-700">
-                        Privacy Policy
-                    </Link>
+                    <div className="flex gap-4">
+                        <Link href="/privacy" className="hover:text-gray-700">
+                            Privacy Policy
+                        </Link>
+                        <Link href="/terms" className="hover:text-gray-700">
+                            Terms of Service
+                        </Link>
+                    </div>
                 </div>
             </div>
         </footer>

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -42,7 +42,8 @@ export async function updateSession(request: NextRequest) {
         !user &&
         !request.nextUrl.pathname.startsWith('/login') &&
         !request.nextUrl.pathname.startsWith('/auth') &&
-        !request.nextUrl.pathname.startsWith('/privacy')
+        !request.nextUrl.pathname.startsWith('/privacy') &&
+        !request.nextUrl.pathname.startsWith('/terms')
     ) {
         // no user, potentially respond by redirecting the user to the login page
         const url = request.nextUrl.clone()


### PR DESCRIPTION
## Summary

- Creates `src/app/terms/page.tsx` as a static Server Component (no auth required) covering: as-is disclaimer, user data responsibility, no warranty/liability, and right to terminate access
- Excludes `/terms` from the auth redirect in `src/lib/supabase/middleware.ts` so unauthenticated users can access it (required for Google OAuth consent screen)
- Adds a Terms of Service link to `Footer.tsx` alongside the existing Privacy Policy link

Closes #5

## Test plan

- [x] Visit `/terms` while logged out — page renders without redirect
- [ ] Visit `/terms` while logged in — page renders normally
- [x] Footer shows both "Privacy Policy" and "Terms of Service" links side by side
- [x] `/privacy` still accessible without auth (existing middleware exclusion preserved)