### PR TITLE
Add category management page (icon/color picker, edit, delete, merge)

### DIFF
--- a/src/app/actions/category-actions.ts
+++ b/src/app/actions/category-actions.ts
@@ -3,6 +3,13 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { Category, CategoryInsert, TransactionType } from "@/types/database";
+import {
+  CATEGORY_COLORS,
+  CATEGORY_ICONS,
+  OTHERS_NAME,
+  OTHERS_COLOR,
+  OTHERS_ICON,
+} from "@/lib/categories/constants";
 
 interface GetCategoriesResult {
   success: boolean;
@@ -10,69 +17,16 @@ interface GetCategoriesResult {
   error?: string;
 }
 
-interface CreateCategoryResult {
+interface CategoryResult {
   success: boolean;
   data?: Category;
   error?: string;
 }
 
-// Color palettes
-const INCOME_COLORS = [
-  "#0d9488", // teal-600
-  "#86efac", // green-300
-  "#22c55e", // green-500
-  "#84cc16", // lime-500
-  "#15803d", // green-700
-  "#052e16", // green-950
-];
-
-const EXPENSE_COLORS = [
-  // Neutrals (high separation anchors)
-  "#000000", // black
-  "#ffffff", // white
-  "#111827", // near-black (slate-900)
-  "#d1d5db", // light gray (gray-300)
-
-  // Reds / warm
-  "#7f1d1d", // deep red
-  "#ef4444", // red
-  "#fb7185", // coral / salmon
-  "#be123c", // raspberry (dark rose)
-
-  // Oranges / yellows (spaced by lightness + warmth)
-  "#c2410c", // burnt orange
-  "#f97316", // orange
-  "#f59e0b", // amber / gold
-  "#fde047", // bright yellow
-  "#a16207", // mustard / ochre
-
-  // Browns / tans (non-green earthy separation)
-  "#7c2d12", // deep brown
-  "#9a3412", // rust
-  "#e0c097", // tan / sand
-  "#fed7aa", // peach
-
-  // Pinks / magentas / purples (varied intensity)
-  "#ec4899", // hot pink
-  "#ff00ff", // pure magenta
-  "#d946ef", // fuchsia
-  "#a21caf", // deep fuchsia
-  "#7e22ce", // purple
-  "#581c87", // deep purple
-  "#7c3aed", // violet
-  "#c4b5fd", // lavender (light violet)
-
-  // Blues (kept “blue”, not cyan/teal)
-  "#1e3a8a", // navy
-  "#2563eb", // blue
-  "#60a5fa", // light blue
-  "#a5b4fc", // periwinkle (indigo-200)
-];
-
-
-
-const MAX_INCOME_CATEGORIES = 6;
-const MAX_EXPENSE_CATEGORIES = 26;
+interface ActionResult {
+  success: boolean;
+  error?: string;
+}
 
 export async function getCategories(): Promise<GetCategoriesResult> {
   try {
@@ -139,9 +93,8 @@ export async function getCategoriesByType(
 
 export async function createCategory(
   category: CategoryInsert
-): Promise<CreateCategoryResult> {
+): Promise<CategoryResult> {
   try {
-    // Validation
     if (!category.name || category.name.trim() === "") {
       return { success: false, error: "Category name is required" };
     }
@@ -150,7 +103,14 @@ export async function createCategory(
       return { success: false, error: "Invalid category type" };
     }
 
-    // Get existing categories for this user and type
+    if (!CATEGORY_COLORS.includes(category.color as typeof CATEGORY_COLORS[number])) {
+      return { success: false, error: "Invalid color selection" };
+    }
+
+    if (!CATEGORY_ICONS.includes(category.icon as typeof CATEGORY_ICONS[number])) {
+      return { success: false, error: "Invalid icon selection" };
+    }
+
     const supabase = await createClient();
     const {
       data: { user },
@@ -160,72 +120,281 @@ export async function createCategory(
       return { success: false, error: "User not authenticated" };
     }
 
-    const { data: existingCategories, error: fetchError } = await supabase
-      .from("categories")
-      .select("color")
-      .eq("user_id", user.id)
-      .eq("category_type", category.category_type);
-
-    if (fetchError) {
-      return { success: false, error: fetchError.message };
-    }
-
-    // Check category limits
-    const categoryCount = existingCategories?.length || 0;
-    const maxCategories =
-      category.category_type === "income" ? MAX_INCOME_CATEGORIES : MAX_EXPENSE_CATEGORIES;
-
-    if (categoryCount >= maxCategories) {
-      return {
-        success: false,
-        error: `You have reached the maximum of ${maxCategories} ${category.category_type} categories. Please delete some categories before creating new ones.`,
-      };
-    }
-
-    // Get available colors for this category type
-    const colorPalette =
-      category.category_type === "income" ? INCOME_COLORS : EXPENSE_COLORS;
-    const usedColors = new Set(existingCategories?.map((c: { color: string }) => c.color) || []);
-    const availableColors = colorPalette.filter((color) => !usedColors.has(color));
-
-    if (availableColors.length === 0) {
-      return {
-        success: false,
-        error: "No available colors for this category type. Please delete some categories first.",
-      };
-    }
-
-    // Pick a random color from available colors
-    const randomColor =
-      availableColors[Math.floor(Math.random() * availableColors.length)];
-
-    // Insert category
     const { data, error } = await supabase
       .from("categories")
       .insert({
         name: category.name.trim(),
         category_type: category.category_type,
-        color: randomColor,
+        color: category.color,
+        icon: category.icon,
         user_id: user.id,
       })
       .select()
       .single();
 
     if (error) {
-      // Check for unique constraint violation
       if (error.code === "23505") {
         return {
           success: false,
-          error: "A category with this name already exists",
+          error: "A category with this name already exists for this type.",
         };
       }
       return { success: false, error: error.message };
     }
 
-    // Revalidate pages that show categories
     revalidatePath("/");
+    revalidatePath("/categories");
 
     return { success: true, data: data as Category };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred",
+    };
+  }
+}
+
+export async function updateCategory(
+  id: string,
+  fields: { name: string; color: string; icon: string }
+): Promise<CategoryResult> {
+  try {
+    if (!fields.name || fields.name.trim() === "") {
+      return { success: false, error: "Category name is required" };
+    }
+
+    if (!CATEGORY_COLORS.includes(fields.color as typeof CATEGORY_COLORS[number])) {
+      return { success: false, error: "Invalid color selection" };
+    }
+
+    if (!CATEGORY_ICONS.includes(fields.icon as typeof CATEGORY_ICONS[number])) {
+      return { success: false, error: "Invalid icon selection" };
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return { success: false, error: "User not authenticated" };
+    }
+
+    const { data, error } = await supabase
+      .from("categories")
+      .update({ name: fields.name.trim(), color: fields.color, icon: fields.icon })
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === "23505") {
+        return {
+          success: false,
+          error: "A category with this name already exists for this type.",
+        };
+      }
+      return { success: false, error: error.message };
+    }
+
+    revalidatePath("/");
+    revalidatePath("/categories");
+
+    return { success: true, data: data as Category };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred",
+    };
+  }
+}
+
+export async function deleteCategory(id: string): Promise<ActionResult> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return { success: false, error: "User not authenticated" };
+    }
+
+    // Load target category (also verifies ownership via user_id)
+    const { data: target, error: targetError } = await supabase
+      .from("categories")
+      .select("*")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (targetError || !target) {
+      return { success: false, error: "Category not found" };
+    }
+
+    // Check if transactions reference this category
+    const { count: txCount } = await supabase
+      .from("transactions")
+      .select("id", { count: "exact", head: true })
+      .eq("category_id", id);
+
+    const hasTransactions = (txCount ?? 0) > 0;
+
+    // Special guard: deleting Others when it has transactions
+    if (target.name === OTHERS_NAME && hasTransactions) {
+      return {
+        success: false,
+        error: "Use merge to move these transactions elsewhere first.",
+      };
+    }
+
+    if (hasTransactions) {
+      // Look for an existing Others category of same type
+      const { data: othersCategory } = await supabase
+        .from("categories")
+        .select("*")
+        .eq("user_id", user.id)
+        .eq("category_type", target.category_type)
+        .eq("name", OTHERS_NAME)
+        .single();
+
+      if (!othersCategory) {
+        // Rename target in place to become Others
+        await supabase
+          .from("categories")
+          .update({ name: OTHERS_NAME, color: OTHERS_COLOR, icon: OTHERS_ICON })
+          .eq("id", id);
+      } else {
+        // Reassign transactions and rules to existing Others, then delete target
+        await supabase
+          .from("transactions")
+          .update({ category_id: othersCategory.id })
+          .eq("category_id", id);
+
+        await supabase
+          .from("merchant_rules")
+          .update({ category_id: othersCategory.id })
+          .eq("category_id", id);
+
+        await supabase.from("categories").delete().eq("id", id);
+      }
+    } else {
+      // No transactions: update or delete merchant_rules then delete category
+      const { data: othersCategory } = await supabase
+        .from("categories")
+        .select("id")
+        .eq("user_id", user.id)
+        .eq("category_type", target.category_type)
+        .eq("name", OTHERS_NAME)
+        .single();
+
+      if (othersCategory) {
+        await supabase
+          .from("merchant_rules")
+          .update({ category_id: othersCategory.id })
+          .eq("category_id", id);
+      } else {
+        await supabase.from("merchant_rules").delete().eq("category_id", id);
+      }
+
+      await supabase.from("categories").delete().eq("id", id);
+    }
+
+    revalidatePath("/");
+    revalidatePath("/categories");
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred",
+    };
+  }
+}
+
+export async function mergeCategories(
+  sourceId: string,
+  targetId: string
+): Promise<ActionResult> {
+  try {
+    if (sourceId === targetId) {
+      return { success: false, error: "Source and target must be different categories" };
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return { success: false, error: "User not authenticated" };
+    }
+
+    // Load both categories and verify ownership
+    const { data: source } = await supabase
+      .from("categories")
+      .select("*")
+      .eq("id", sourceId)
+      .eq("user_id", user.id)
+      .single();
+
+    const { data: target } = await supabase
+      .from("categories")
+      .select("*")
+      .eq("id", targetId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (!source || !target) {
+      return { success: false, error: "Category not found" };
+    }
+
+    if (source.category_type !== target.category_type) {
+      return { success: false, error: "Cannot merge categories of different types" };
+    }
+
+    // Reassign transactions
+    await supabase
+      .from("transactions")
+      .update({ category_id: targetId })
+      .eq("category_id", sourceId);
+
+    // Reassign merchant_rules; delete source rule on (user_id, match_pattern) conflict
+    const { data: sourceRules } = await supabase
+      .from("merchant_rules")
+      .select("id, match_pattern")
+      .eq("category_id", sourceId);
+
+    if (sourceRules && sourceRules.length > 0) {
+      const { data: targetRules } = await supabase
+        .from("merchant_rules")
+        .select("match_pattern")
+        .eq("user_id", user.id)
+        .eq("category_id", targetId);
+
+      const targetPatterns = new Set((targetRules ?? []).map((r: { match_pattern: string }) => r.match_pattern));
+
+      for (const rule of sourceRules) {
+        if (targetPatterns.has(rule.match_pattern)) {
+          // Conflict: delete the source rule
+          await supabase.from("merchant_rules").delete().eq("id", rule.id);
+        } else {
+          await supabase
+            .from("merchant_rules")
+            .update({ category_id: targetId })
+            .eq("id", rule.id);
+        }
+      }
+    }
+
+    // Delete source category
+    await supabase.from("categories").delete().eq("id", sourceId);
+
+    revalidatePath("/");
+    revalidatePath("/categories");
+
+    return { success: true };
   } catch (error) {
     return {
       success: false,

--- a/src/app/actions/transaction-actions.ts
+++ b/src/app/actions/transaction-actions.ts
@@ -13,7 +13,7 @@ type MonthTransaction = {
   amount: number;
   type: TransactionType;
   category_id: string | null;
-  categories: Pick<Category, 'name' | 'color'> | Pick<Category, 'name' | 'color'>[] | null;
+  categories: Pick<Category, 'name' | 'color' | 'icon'> | Pick<Category, 'name' | 'color' | 'icon'>[] | null;
 };
 
 interface GetTransactionsResult {
@@ -40,6 +40,7 @@ interface CategoryBreakdownItem {
   categoryId: string | null;
   name: string;
   color: string | null;
+  icon: string;
   total: number;
   type: TransactionType;
 }
@@ -218,7 +219,7 @@ export async function getDashboardSummary(month?: string): Promise<GetDashboardS
 
     const { data: monthTransactions, error: monthError } = await supabase
       .from("transactions")
-      .select("amount, type, category_id, categories(name, color)")
+      .select("amount, type, category_id, categories(name, color, icon)")
       .eq("user_id", user.id)
       .gte("date", startOfMonthString)
       .lte("date", endOfMonthString);
@@ -318,6 +319,7 @@ function buildCategoryBreakdown(
 
     const name = categoryData?.name || "Uncategorized";
     const color = categoryData?.color || null;
+    const icon = categoryData?.icon || "circle";
 
     const existing = breakdownMap.get(id);
     if (existing) {
@@ -329,6 +331,7 @@ function buildCategoryBreakdown(
       categoryId: transaction.category_id,
       name,
       color,
+      icon,
       total: transaction.amount,
       type: transaction.type,
     });

--- a/src/app/categories/CategoryRow.tsx
+++ b/src/app/categories/CategoryRow.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { Category } from "@/types/database";
+import { CategoryIcon } from "@/components/CategoryIcon";
+import { CategoryForm } from "@/components/CategoryForm";
+import { DeleteCategoryDialog } from "@/components/DeleteCategoryDialog";
+import { MergeCategoryDialog } from "@/components/MergeCategoryDialog";
+import { Modal } from "@/components/Modal";
+import { updateCategory } from "@/app/actions/category-actions";
+import { Pencil, Trash2, GitMerge } from "lucide-react";
+
+interface CategoryRowProps {
+    category: Category;
+    transactionCount: number;
+    sameTypePeers: Category[];
+}
+
+export function CategoryRow({ category, transactionCount, sameTypePeers }: CategoryRowProps) {
+    const [editOpen, setEditOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [mergeOpen, setMergeOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [editError, setEditError] = useState<string | null>(null);
+
+    async function handleEdit(data: { name: string; category_type: "income" | "expense"; color: string; icon: string }) {
+        setIsSubmitting(true);
+        setEditError(null);
+        const result = await updateCategory(category.id, { name: data.name, color: data.color, icon: data.icon });
+        setIsSubmitting(false);
+        if (result.success) {
+            setEditOpen(false);
+        } else {
+            setEditError(result.error ?? "Failed to update category");
+        }
+    }
+
+    return (
+        <div className="flex items-center gap-3 py-3 px-4 rounded-lg border border-zinc-100 dark:border-zinc-800 bg-white dark:bg-zinc-900">
+            <span
+                className="flex items-center justify-center w-8 h-8 rounded-full flex-shrink-0"
+                style={{ backgroundColor: category.color }}
+            >
+                <CategoryIcon name={category.icon} size={16} color="white" />
+            </span>
+
+            <span className="flex-1 text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
+                {category.name}
+            </span>
+
+            <span className="text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+                {transactionCount} {transactionCount === 1 ? "transaction" : "transactions"}
+            </span>
+
+            <div className="flex items-center gap-1 flex-shrink-0">
+                <button
+                    type="button"
+                    onClick={() => setEditOpen(true)}
+                    title="Edit"
+                    className="p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 dark:hover:text-zinc-200 dark:hover:bg-zinc-800 transition-colors"
+                >
+                    <Pencil size={14} />
+                </button>
+                {sameTypePeers.length > 0 && (
+                    <button
+                        type="button"
+                        onClick={() => setMergeOpen(true)}
+                        title="Merge"
+                        className="p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 dark:hover:text-zinc-200 dark:hover:bg-zinc-800 transition-colors"
+                    >
+                        <GitMerge size={14} />
+                    </button>
+                )}
+                <button
+                    type="button"
+                    onClick={() => setDeleteOpen(true)}
+                    title="Delete"
+                    className="p-1.5 rounded-md text-zinc-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors"
+                >
+                    <Trash2 size={14} />
+                </button>
+            </div>
+
+            <Modal isOpen={editOpen} onClose={() => setEditOpen(false)} title={`Edit "${category.name}"`}>
+                <CategoryForm
+                    mode="edit"
+                    initial={category}
+                    onSubmit={handleEdit}
+                    onCancel={() => setEditOpen(false)}
+                    isSubmitting={isSubmitting}
+                    error={editError}
+                />
+            </Modal>
+
+            <DeleteCategoryDialog
+                category={category}
+                transactionCount={transactionCount}
+                isOpen={deleteOpen}
+                onClose={() => setDeleteOpen(false)}
+            />
+
+            <MergeCategoryDialog
+                source={category}
+                candidates={sameTypePeers}
+                isOpen={mergeOpen}
+                onClose={() => setMergeOpen(false)}
+            />
+        </div>
+    );
+}

--- a/src/app/categories/NewCategoryButton.tsx
+++ b/src/app/categories/NewCategoryButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { createCategory } from "@/app/actions/category-actions";
+import { CategoryForm } from "@/components/CategoryForm";
+import { Modal } from "@/components/Modal";
+import { Plus } from "lucide-react";
+import { TransactionType } from "@/types/database";
+
+export function NewCategoryButton() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleSubmit(data: { name: string; category_type: TransactionType; color: string; icon: string }) {
+        setIsSubmitting(true);
+        setError(null);
+        const result = await createCategory(data);
+        setIsSubmitting(false);
+        if (result.success) {
+            setIsOpen(false);
+        } else {
+            setError(result.error ?? "Failed to create category");
+        }
+    }
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setIsOpen(true)}
+                className="inline-flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors"
+            >
+                <Plus size={16} />
+                New Category
+            </button>
+
+            <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} title="New Category">
+                <CategoryForm
+                    mode="create"
+                    onSubmit={handleSubmit}
+                    onCancel={() => setIsOpen(false)}
+                    isSubmitting={isSubmitting}
+                    error={error}
+                />
+            </Modal>
+        </>
+    );
+}

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,0 +1,90 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { getCategories } from "@/app/actions/category-actions";
+import { Category } from "@/types/database";
+import { CategoryRow } from "./CategoryRow";
+import { NewCategoryButton } from "./NewCategoryButton";
+
+export default async function CategoriesPage() {
+    const supabase = await createClient();
+    const {
+        data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+        redirect("/login");
+    }
+
+    const categoriesResult = await getCategories();
+    const categories: Category[] = categoriesResult.data ?? [];
+
+    // Fetch transaction counts per category
+    const { data: countRows } = await supabase
+        .from("transactions")
+        .select("category_id")
+        .eq("user_id", user.id);
+
+    const txCountMap = new Map<string, number>();
+    for (const row of countRows ?? []) {
+        if (row.category_id) {
+            txCountMap.set(row.category_id, (txCountMap.get(row.category_id) ?? 0) + 1);
+        }
+    }
+
+    const income = categories.filter((c) => c.category_type === "income");
+    const expense = categories.filter((c) => c.category_type === "expense");
+
+    return (
+        <div className="mx-auto max-w-4xl px-4 py-8">
+            <div className="flex items-center justify-between mb-8">
+                <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Categories</h1>
+                <NewCategoryButton />
+            </div>
+
+            <div className="space-y-8">
+                <Section
+                    title="Income"
+                    categories={income}
+                    txCountMap={txCountMap}
+                />
+                <Section
+                    title="Expense"
+                    categories={expense}
+                    txCountMap={txCountMap}
+                />
+            </div>
+        </div>
+    );
+}
+
+function Section({
+    title,
+    categories,
+    txCountMap,
+}: {
+    title: string;
+    categories: Category[];
+    txCountMap: Map<string, number>;
+}) {
+    return (
+        <div>
+            <h2 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-3">
+                {title}
+            </h2>
+            {categories.length === 0 ? (
+                <p className="text-sm text-zinc-400 italic">No {title.toLowerCase()} categories yet.</p>
+            ) : (
+                <div className="space-y-2">
+                    {categories.map((cat) => (
+                        <CategoryRow
+                            key={cat.id}
+                            category={cat}
+                            transactionCount={txCountMap.get(cat.id) ?? 0}
+                            sameTypePeers={categories.filter((c) => c.id !== cat.id)}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,10 +28,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
       >
         <Navbar />
-        {children}
+        <main className="flex-1">{children}</main>
         <Footer />
         {process.env.NODE_ENV === "development" && <DebugPane />}
       </body>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -72,16 +72,16 @@ export default function LoginPage() {
     }
 
     return (
-        <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+        <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
             <div className="w-full max-w-md space-y-6">
-                <h2 className="text-center text-3xl font-bold tracking-tight text-gray-900">
+                <h2 className="text-center text-3xl font-bold tracking-tight text-gray-900 dark:text-zinc-50">
                     Sign in to Budget Buddy
                 </h2>
 
                 <button
                     onClick={handleGoogleSignIn}
                     disabled={isGoogleLoading}
-                    className="flex w-full items-center justify-center gap-3 rounded-md border border-gray-300 bg-white px-3 py-2.5 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50"
+                    className="flex w-full items-center justify-center gap-3 rounded-md border border-gray-300 bg-white px-3 py-2.5 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
                 >
                     {isGoogleLoading ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -98,19 +98,19 @@ export default function LoginPage() {
 
                 <div className="relative">
                     <div className="absolute inset-0 flex items-center">
-                        <div className="w-full border-t border-gray-300" />
+                        <div className="w-full border-t border-gray-300 dark:border-zinc-700" />
                     </div>
                     <div className="relative flex justify-center text-sm">
-                        <span className="bg-gray-50 px-2 text-gray-500">or</span>
+                        <span className="bg-gray-50 px-2 text-gray-500 dark:bg-black dark:text-zinc-400">or</span>
                     </div>
                 </div>
 
                 <button
                     onClick={() => setShowEmailForm(!showEmailForm)}
-                    className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
                 >
                     <span>Sign in with email</span>
-                    <span className="text-gray-400">{showEmailForm ? '▲' : '▾'}</span>
+                    <span className="text-gray-400 dark:text-zinc-500">{showEmailForm ? '▲' : '▾'}</span>
                 </button>
 
                 {showEmailForm && (
@@ -124,7 +124,7 @@ export default function LoginPage() {
                                     type="email"
                                     autoComplete="email"
                                     required
-                                    className="relative block w-full rounded-t-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 px-3"
+                                    className="relative block w-full rounded-t-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 px-3 dark:bg-zinc-900 dark:text-zinc-100 dark:ring-zinc-700 dark:placeholder:text-zinc-500 dark:focus:ring-blue-500"
                                     placeholder="Email"
                                     value={email}
                                     onChange={(e) => setEmail(e.target.value)}
@@ -138,7 +138,7 @@ export default function LoginPage() {
                                     type="password"
                                     autoComplete="current-password"
                                     required
-                                    className="relative block w-full rounded-b-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 px-3"
+                                    className="relative block w-full rounded-b-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 px-3 dark:bg-zinc-900 dark:text-zinc-100 dark:ring-zinc-700 dark:placeholder:text-zinc-500 dark:focus:ring-blue-500"
                                     placeholder="Password"
                                     value={password}
                                     onChange={(e) => setPassword(e.target.value)}
@@ -147,14 +147,14 @@ export default function LoginPage() {
                         </div>
 
                         {error && (
-                            <div className="rounded-md bg-red-50 p-4">
-                                <p className="text-sm font-medium text-red-800">{error}</p>
+                            <div className="rounded-md bg-red-50 p-4 dark:bg-red-950">
+                                <p className="text-sm font-medium text-red-800 dark:text-red-300">{error}</p>
                             </div>
                         )}
 
                         {message && (
-                            <div className="rounded-md bg-green-50 p-4">
-                                <p className="text-sm font-medium text-green-800">{message}</p>
+                            <div className="rounded-md bg-green-50 p-4 dark:bg-green-950">
+                                <p className="text-sm font-medium text-green-800 dark:text-green-300">{message}</p>
                             </div>
                         )}
 
@@ -167,7 +167,7 @@ export default function LoginPage() {
                             {mode === 'signin' ? 'Sign in' : 'Sign up'}
                         </button>
 
-                        <p className="text-center text-sm text-gray-600">
+                        <p className="text-center text-sm text-gray-600 dark:text-zinc-400">
                             <button
                                 type="button"
                                 onClick={() => {
@@ -177,7 +177,7 @@ export default function LoginPage() {
                                     setEmail('')
                                     setPassword('')
                                 }}
-                                className="font-medium text-blue-600 hover:text-blue-500"
+                                className="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
                             >
                                 {mode === 'signin' ? 'Or sign up instead' : 'Or sign in instead'}
                             </button>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -72,7 +72,7 @@ export default function LoginPage() {
     }
 
     return (
-        <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
+        <div className="flex min-h-full flex-col items-center justify-center bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
             <div className="w-full max-w-md space-y-6">
                 <h2 className="text-center text-3xl font-bold tracking-tight text-gray-900 dark:text-zinc-50">
                     Sign in to Budget Buddy

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,15 +1,15 @@
 export default function PrivacyPage() {
     return (
-        <div className="min-h-screen bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+        <div className="min-h-screen bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
             <div className="mx-auto max-w-2xl space-y-8">
                 <div>
-                    <h1 className="text-3xl font-bold tracking-tight text-gray-900">Privacy Policy</h1>
-                    <p className="mt-2 text-sm text-gray-500">Last updated: April 2025</p>
+                    <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-zinc-50">Privacy Policy</h1>
+                    <p className="mt-2 text-sm text-gray-500 dark:text-zinc-400">Last updated: April 2025</p>
                 </div>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">Data We Collect</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">Data We Collect</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         When you sign in with Google, we receive your name and email address from your Google profile.
                         If you sign up with email and password, we store only your email address.
                         Beyond authentication, Budget Buddy stores the financial transaction data and categories you enter.
@@ -17,8 +17,8 @@ export default function PrivacyPage() {
                 </section>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">How We Use Your Data</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">How We Use Your Data</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         Your name and email are used solely to authenticate you and identify your account.
                         Transaction data and categories are used to provide personal finance tracking features within the app.
                         We do not use your data for advertising, analytics, or any purpose beyond operating the service.
@@ -26,27 +26,27 @@ export default function PrivacyPage() {
                 </section>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">Data Storage</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">Data Storage</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         All data is stored securely in the cloud.
                         Access controls ensure your data is strictly isolated and cannot be accessed by other users.
                     </p>
                 </section>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">Data Sharing</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">Data Sharing</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         We do not sell, share, or disclose your data to any third parties.
                     </p>
                 </section>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">Contact</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">Contact</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         For data requests or questions about this policy, contact:{' '}
                         <a
                             href="mailto:cristofor.nogueira@gmail.com"
-                            className="text-blue-600 hover:text-blue-500"
+                            className="text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
                         >
                             cristofor.nogueira@gmail.com
                         </a>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,6 @@
 export default function PrivacyPage() {
     return (
-        <div className="min-h-screen bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
+        <div className="bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
             <div className="mx-auto max-w-2xl space-y-8">
                 <div>
                     <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-zinc-50">Privacy Policy</h1>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,15 +1,15 @@
 export default function TermsPage() {
     return (
-        <div className="min-h-screen bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+        <div className="min-h-screen bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
             <div className="mx-auto max-w-2xl space-y-8">
                 <div>
-                    <h1 className="text-3xl font-bold tracking-tight text-gray-900">Terms of Service</h1>
-                    <p className="mt-2 text-sm text-gray-500">Last updated: April 2025</p>
+                    <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-zinc-50">Terms of Service</h1>
+                    <p className="mt-2 text-sm text-gray-500 dark:text-zinc-400">Last updated: April 2025</p>
                 </div>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">Provided As-Is</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">Provided As-Is</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         Budget Buddy is a personal finance tracking tool provided as-is, without warranty of any kind,
                         express or implied. We make no guarantees about accuracy, availability, or fitness for any
                         particular purpose.
@@ -17,8 +17,8 @@ export default function TermsPage() {
                 </section>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">Your Data</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">Your Data</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         You are solely responsible for the data you enter into the app. We do not verify the accuracy
                         of any financial information you provide, and we are not liable for any decisions made based
                         on data stored in Budget Buddy.
@@ -26,8 +26,8 @@ export default function TermsPage() {
                 </section>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">No Warranty or Liability</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">No Warranty or Liability</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         To the fullest extent permitted by applicable law, we disclaim all warranties and shall not
                         be liable for any direct, indirect, incidental, or consequential damages arising from your
                         use of this service.
@@ -35,8 +35,8 @@ export default function TermsPage() {
                 </section>
 
                 <section className="space-y-3">
-                    <h2 className="text-xl font-semibold text-gray-900">Termination</h2>
-                    <p className="text-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-zinc-50">Termination</h2>
+                    <p className="text-gray-700 dark:text-zinc-300">
                         We reserve the right to suspend or terminate your access to Budget Buddy at any time, for
                         any reason, without prior notice.
                     </p>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,6 +1,6 @@
 export default function TermsPage() {
     return (
-        <div className="min-h-screen bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
+        <div className="bg-gray-50 dark:bg-black px-4 py-12 sm:px-6 lg:px-8">
             <div className="mx-auto max-w-2xl space-y-8">
                 <div>
                     <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-zinc-50">Terms of Service</h1>

--- a/src/components/AddTransactionForm.tsx
+++ b/src/components/AddTransactionForm.tsx
@@ -3,8 +3,9 @@
 import { addTransaction } from "@/app/actions/transaction-actions";
 import { getCategories, createCategory } from "@/app/actions/category-actions";
 import { TransactionType, Category } from "@/types/database";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { CategorySelector } from "./CategorySelector";
+import { CategoryForm } from "./CategoryForm";
 
 interface AddTransactionFormProps {
   onSuccess?: () => void;
@@ -14,7 +15,6 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
   const [amount, setAmount] = useState("");
   const [type, setType] = useState<TransactionType>("expense");
   const [categoryId, setCategoryId] = useState("");
-  const [newCategoryName, setNewCategoryName] = useState("");
   const [isCreatingCategory, setIsCreatingCategory] = useState(false);
   const [allCategories, setAllCategories] = useState<Category[]>([]);
   const [description, setDescription] = useState("");
@@ -22,11 +22,11 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoadingCategories, setIsLoadingCategories] = useState(true);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [isCreatingSubmitting, setIsCreatingSubmitting] = useState(false);
 
   // Filter categories locally based on the selected type
-  const categories = useMemo(() => {
-    return allCategories.filter(cat => cat.category_type === type);
-  }, [allCategories, type]);
+  const categories = allCategories.filter((cat) => cat.category_type === type);
 
   // Fetch all categories once when the form mounts
   useEffect(() => {
@@ -41,33 +41,23 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
     loadCategories();
   }, []);
 
-  async function handleCreateCategory() {
-    if (!newCategoryName.trim()) {
-      setMessage({ type: "error", text: "Please enter a category name" });
-      setTimeout(() => setMessage(null), 3000);
-      return;
-    }
-
-    setIsSubmitting(true);
-    const result = await createCategory({
-      name: newCategoryName.trim(),
-      category_type: type,
-      color: "", // Server will assign color
-    });
-
-    setIsSubmitting(false);
+  async function handleCreateCategory(data: {
+    name: string;
+    category_type: TransactionType;
+    color: string;
+    icon: string;
+  }) {
+    setIsCreatingSubmitting(true);
+    setCreateError(null);
+    const result = await createCategory(data);
+    setIsCreatingSubmitting(false);
 
     if (result.success && result.data) {
-      // Add new category to allCategories list and select it
       setAllCategories([...allCategories, result.data]);
       setCategoryId(result.data.id);
       setIsCreatingCategory(false);
-      setNewCategoryName("");
-      setMessage({ type: "success", text: "Category created!" });
-      setTimeout(() => setMessage(null), 3000);
     } else {
-      setMessage({ type: "error", text: result.error || "Failed to create category" });
-      setTimeout(() => setMessage(null), 3000);
+      setCreateError(result.error ?? "Failed to create category");
     }
   }
 
@@ -75,14 +65,6 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
     e.preventDefault();
     setIsSubmitting(true);
     setMessage(null);
-
-    // If creating a new category, create it first
-    if (isCreatingCategory && newCategoryName.trim()) {
-      await handleCreateCategory();
-      // Don't submit transaction yet, let user confirm category was created
-      setIsSubmitting(false);
-      return;
-    }
 
     if (!categoryId) {
       setMessage({ type: "error", text: "Please select or create a category" });
@@ -103,27 +85,23 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
 
     if (result.success) {
       setMessage({ type: "success", text: "Transaction added successfully!" });
-      // Reset form
       setAmount("");
       setCategoryId("");
       setDescription("");
       setDate(getTodayDate());
 
-      // Notify parent of success
       if (onSuccess) {
-        setTimeout(() => onSuccess(), 1500); // Small delay to show success message
+        setTimeout(() => onSuccess(), 1500);
       }
     } else {
       setMessage({ type: "error", text: result.error || "Failed to add transaction" });
     }
 
-    // Clear message after 3 seconds
     setTimeout(() => setMessage(null), 3000);
   }
 
   return (
     <div className="bg-white dark:bg-zinc-950">
-
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {/* Amount */}
@@ -151,35 +129,46 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
             </label>
             <div className="mt-1 grid grid-cols-2 p-1 bg-zinc-100 dark:bg-zinc-800 rounded-lg relative">
               <div
-                className={`absolute inset-y-1 w-[calc(50%-4px)] rounded-md shadow-sm transition-all duration-300 ease-in-out ${type === 'expense'
-                  ? 'translate-x-0 bg-red-500 dark:bg-red-600'
-                  : 'translate-x-full bg-emerald-500 dark:bg-emerald-600'
-                  }`}
+                className={`absolute inset-y-1 w-[calc(50%-4px)] rounded-md shadow-sm transition-all duration-300 ease-in-out ${
+                  type === "expense"
+                    ? "translate-x-0 bg-red-500 dark:bg-red-600"
+                    : "translate-x-full bg-emerald-500 dark:bg-emerald-600"
+                }`}
               />
               <label
-                className={`relative flex items-center justify-center py-2 text-sm font-bold cursor-pointer transition-colors duration-300 z-10 ${type === 'expense' ? 'text-white' : 'text-zinc-500 dark:text-zinc-400'
-                  }`}
+                className={`relative flex items-center justify-center py-2 text-sm font-bold cursor-pointer transition-colors duration-300 z-10 ${
+                  type === "expense" ? "text-white" : "text-zinc-500 dark:text-zinc-400"
+                }`}
               >
                 <input
                   type="radio"
                   name="transactionType"
                   value="expense"
-                  checked={type === 'expense'}
-                  onChange={() => { setType('expense'); setCategoryId(''); setIsCreatingCategory(false); setNewCategoryName(''); }}
+                  checked={type === "expense"}
+                  onChange={() => {
+                    setType("expense");
+                    setCategoryId("");
+                    setIsCreatingCategory(false);
+                  }}
                   className="sr-only"
                 />
                 Expense
               </label>
               <label
-                className={`relative flex items-center justify-center py-2 text-sm font-bold cursor-pointer transition-colors duration-300 z-10 ${type === 'income' ? 'text-white' : 'text-zinc-500 dark:text-zinc-400'
-                  }`}
+                className={`relative flex items-center justify-center py-2 text-sm font-bold cursor-pointer transition-colors duration-300 z-10 ${
+                  type === "income" ? "text-white" : "text-zinc-500 dark:text-zinc-400"
+                }`}
               >
                 <input
                   type="radio"
                   name="transactionType"
                   value="income"
-                  checked={type === 'income'}
-                  onChange={() => { setType('income'); setCategoryId(''); setIsCreatingCategory(false); setNewCategoryName(''); }}
+                  checked={type === "income"}
+                  onChange={() => {
+                    setType("income");
+                    setCategoryId("");
+                    setIsCreatingCategory(false);
+                  }}
                   className="sr-only"
                 />
                 Income
@@ -205,36 +194,17 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
             </div>
 
             {isCreatingCategory ? (
-              <div className="flex flex-col gap-2 animate-in fade-in slide-in-from-top-1 duration-200">
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    autoFocus
-                    value={newCategoryName}
-                    onChange={(e) => setNewCategoryName(e.target.value)}
-                    className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:border-zinc-500"
-                    placeholder="Enter new category name"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleCreateCategory}
-                    disabled={isSubmitting || !newCategoryName.trim()}
-                    className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 disabled:opacity-50 transition-colors"
-                  >
-                    Create
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setIsCreatingCategory(false);
-                      setNewCategoryName("");
-                    }}
-                    className="rounded-md bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700 transition-colors"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
+              <CategoryForm
+                mode="create"
+                lockedType={type}
+                onSubmit={handleCreateCategory}
+                onCancel={() => {
+                  setIsCreatingCategory(false);
+                  setCreateError(null);
+                }}
+                isSubmitting={isCreatingSubmitting}
+                error={createError}
+              />
             ) : (
               <CategorySelector
                 categories={categories}
@@ -286,13 +256,13 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
             {isSubmitting ? "Adding..." : "Add Transaction"}
           </button>
 
-          {/* Success/Error Message */}
           {message && (
             <div
-              className={`text-sm font-medium ${message.type === "success"
-                ? "text-green-600 dark:text-green-400"
-                : "text-red-600 dark:text-red-400"
-                }`}
+              className={`text-sm font-medium ${
+                message.type === "success"
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-red-600 dark:text-red-400"
+              }`}
             >
               {message.text}
             </div>

--- a/src/components/CategoryForm.tsx
+++ b/src/components/CategoryForm.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { Category, TransactionType } from "@/types/database";
+import { DEFAULT_NEW_CATEGORY_COLOR, DEFAULT_NEW_CATEGORY_ICON } from "@/lib/categories/constants";
+import { IconPicker } from "./IconPicker";
+import { ColorPicker } from "./ColorPicker";
+
+interface CategoryFormProps {
+    mode: "create" | "edit";
+    initial?: Category;
+    lockedType?: TransactionType;
+    onSubmit: (data: { name: string; category_type: TransactionType; color: string; icon: string }) => Promise<void>;
+    onCancel: () => void;
+    isSubmitting?: boolean;
+    error?: string | null;
+}
+
+export function CategoryForm({
+    mode,
+    initial,
+    lockedType,
+    onSubmit,
+    onCancel,
+    isSubmitting,
+    error,
+}: CategoryFormProps) {
+    const [name, setName] = useState(initial?.name ?? "");
+    const [type, setType] = useState<TransactionType>(
+        lockedType ?? initial?.category_type ?? "expense"
+    );
+    const [color, setColor] = useState(initial?.color ?? DEFAULT_NEW_CATEGORY_COLOR);
+    const [icon, setIcon] = useState(initial?.icon ?? DEFAULT_NEW_CATEGORY_ICON);
+
+    const effectiveType = lockedType ?? type;
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        await onSubmit({ name, category_type: effectiveType, color, icon });
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                    Name
+                </label>
+                <input
+                    type="text"
+                    autoFocus
+                    required
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:border-zinc-500"
+                    placeholder="Category name"
+                />
+            </div>
+
+            {mode === "create" && !lockedType && (
+                <div>
+                    <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                        Type
+                    </label>
+                    <div className="grid grid-cols-2 p-1 bg-zinc-100 dark:bg-zinc-800 rounded-lg relative">
+                        <div
+                            className={`absolute inset-y-1 w-[calc(50%-4px)] rounded-md shadow-sm transition-all duration-300 ease-in-out ${
+                                type === "expense"
+                                    ? "translate-x-0 bg-red-500 dark:bg-red-600"
+                                    : "translate-x-full bg-emerald-500 dark:bg-emerald-600"
+                            }`}
+                        />
+                        <label
+                            className={`relative flex items-center justify-center py-2 text-sm font-bold cursor-pointer transition-colors duration-300 z-10 ${
+                                type === "expense" ? "text-white" : "text-zinc-500 dark:text-zinc-400"
+                            }`}
+                        >
+                            <input
+                                type="radio"
+                                name="categoryType"
+                                value="expense"
+                                checked={type === "expense"}
+                                onChange={() => setType("expense")}
+                                className="sr-only"
+                            />
+                            Expense
+                        </label>
+                        <label
+                            className={`relative flex items-center justify-center py-2 text-sm font-bold cursor-pointer transition-colors duration-300 z-10 ${
+                                type === "income" ? "text-white" : "text-zinc-500 dark:text-zinc-400"
+                            }`}
+                        >
+                            <input
+                                type="radio"
+                                name="categoryType"
+                                value="income"
+                                checked={type === "income"}
+                                onChange={() => setType("income")}
+                                className="sr-only"
+                            />
+                            Income
+                        </label>
+                    </div>
+                </div>
+            )}
+
+            <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                    Icon
+                </label>
+                <IconPicker value={icon} onChange={setIcon} />
+            </div>
+
+            <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                    Color
+                </label>
+                <ColorPicker value={color} onChange={setColor} />
+            </div>
+
+            {error && (
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="rounded-md bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700 transition-colors"
+                >
+                    Cancel
+                </button>
+                <button
+                    type="submit"
+                    disabled={isSubmitting || !name.trim()}
+                    className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 disabled:opacity-50 transition-colors"
+                >
+                    {isSubmitting ? "Saving..." : mode === "create" ? "Create" : "Save"}
+                </button>
+            </div>
+        </form>
+    );
+}

--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -7,10 +7,12 @@ interface CategoryIconProps extends LucideProps {
     color?: string;
 }
 
-export function CategoryIcon({ name, color, ...props }: CategoryIconProps) {
-    // Map string to Lucide component
-    // Use a fallback if the icon name is not found
-    const IconComponent = (Icons as unknown as Record<string, ComponentType<LucideProps>>)[name] || Icons.HelpCircle;
+function toPascalCase(name: string): string {
+    return name.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join('');
+}
 
+export function CategoryIcon({ name, color, ...props }: CategoryIconProps) {
+    const pascalName = toPascalCase(name);
+    const IconComponent = (Icons as unknown as Record<string, ComponentType<LucideProps>>)[pascalName] || Icons.HelpCircle;
     return <IconComponent color={color} {...props} />;
 }

--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -4,12 +4,14 @@ import { useState, useRef } from "react";
 import { Category } from "@/types/database";
 import { updateTransactionCategory } from "@/app/actions/learning-actions";
 import { Check, ChevronDown, Loader2 } from "lucide-react";
+import { CategoryIcon } from "./CategoryIcon";
 
 interface CategoryPickerProps {
     transactionId: string;
     currentCategoryId: string | null;
     currentCategoryName: string;
     currentCategoryColor: string;
+    currentCategoryIcon: string;
     categories: Category[];
 }
 
@@ -18,6 +20,7 @@ export function CategoryPicker({
     currentCategoryId,
     currentCategoryName,
     currentCategoryColor,
+    currentCategoryIcon,
     categories
 }: CategoryPickerProps) {
     const [isOpen, setIsOpen] = useState(false);
@@ -45,7 +48,6 @@ export function CategoryPicker({
         if (!isOpen && buttonRef.current) {
             const rect = buttonRef.current.getBoundingClientRect();
             const spaceBelow = window.innerHeight - rect.bottom;
-            // Dropdown has max-h-60 (240px) + some margin
             setOpenUpward(spaceBelow < 260);
         }
         setIsOpen(!isOpen);
@@ -57,12 +59,15 @@ export function CategoryPicker({
                 ref={buttonRef}
                 type="button"
                 onClick={toggleDropdown}
-                className={`inline-flex items-center gap-2 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all ${isUpdating ? "opacity-50 cursor-not-allowed" : "hover:scale-105 active:scale-95"
+                className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all ${isUpdating ? "opacity-50 cursor-not-allowed" : "hover:scale-105 active:scale-95"
                     }`}
                 style={{ backgroundColor: currentCategoryColor, color: '#fff' }}
                 disabled={isUpdating}
             >
-                {isUpdating ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+                {isUpdating
+                    ? <Loader2 className="h-3 w-3 animate-spin" />
+                    : <CategoryIcon name={currentCategoryIcon} size={11} color="white" />
+                }
                 {currentCategoryName}
                 <ChevronDown className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`} />
             </button>
@@ -73,7 +78,7 @@ export function CategoryPicker({
                         className="fixed inset-0 z-20"
                         onClick={() => setIsOpen(false)}
                     />
-                    <div className={`absolute left-0 w-48 rounded-md bg-white p-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-zinc-900 dark:ring-zinc-800 z-30 max-h-60 overflow-y-auto ${openUpward ? "bottom-full mb-2 origin-bottom-left" : "top-full mt-2 origin-top-left"
+                    <div className={`absolute left-0 w-52 rounded-md bg-white p-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-zinc-900 dark:ring-zinc-800 z-30 max-h-60 overflow-y-auto ${openUpward ? "bottom-full mb-2 origin-bottom-left" : "top-full mt-2 origin-top-left"
                         }`}>
                         {categories.map((cat) => (
                             <button
@@ -82,9 +87,11 @@ export function CategoryPicker({
                                 className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
                             >
                                 <span
-                                    className="h-2 w-2 rounded-full"
+                                    className="flex items-center justify-center w-5 h-5 rounded-full flex-shrink-0"
                                     style={{ backgroundColor: cat.color }}
-                                />
+                                >
+                                    <CategoryIcon name={cat.icon} size={11} color="white" />
+                                </span>
                                 <span className="flex-1 text-left">{cat.name}</span>
                                 {cat.id === currentCategoryId && (
                                     <Check className="h-3 w-3 text-zinc-500" />

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { Category } from "@/types/database";
 import { CategoryIcon } from "./CategoryIcon";
 
@@ -15,74 +14,34 @@ export function CategorySelector({
     categories,
     selectedId,
     onSelect,
-    isLoading
+    isLoading,
 }: CategorySelectorProps) {
-
-    const hierarchicalCategories = useMemo(() => {
-        // 1. Separate parents and children
-        const parents = categories.filter(c => !c.parent_id);
-        const childrenByParent = new Map<string, Category[]>();
-
-        categories.forEach(c => {
-            if (c.parent_id) {
-                const group = childrenByParent.get(c.parent_id) || [];
-                group.push(c);
-                childrenByParent.set(c.parent_id, group);
-            }
-        });
-
-        return parents.map(p => ({
-            ...p,
-            children: childrenByParent.get(p.id) || []
-        }));
-    }, [categories]);
-
     if (isLoading) {
         return (
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <div className="flex flex-wrap gap-2">
                 {[1, 2, 3, 4, 5, 6].map((i) => (
-                    <div key={i} className="h-10 bg-zinc-100 dark:bg-zinc-800 animate-pulse rounded-full" />
+                    <div key={i} className="h-8 w-20 bg-zinc-100 dark:bg-zinc-800 animate-pulse rounded-full" />
                 ))}
             </div>
         );
     }
 
+    if (categories.length === 0) {
+        return (
+            <p className="text-sm text-zinc-500 italic">No categories found. Create one to get started.</p>
+        );
+    }
+
     return (
-        <div className="space-y-4 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
-            {hierarchicalCategories.length > 0 ? (
-                hierarchicalCategories.map((parent) => (
-                    <div key={parent.id} className="space-y-2">
-                        {/* Parent Header */}
-                        <div className="flex items-center gap-2 px-1">
-                            <CategoryIcon name={parent.icon} size={14} className="text-zinc-400" />
-                            <span className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
-                                {parent.name}
-                            </span>
-                        </div>
-
-                        {/* Combined List including Parent (if it can be selected) and Children */}
-                        <div className="flex flex-wrap gap-2">
-                            {/* Option to select the parent itself if desired, or just show children */}
-                            <CategoryPill
-                                category={parent}
-                                isSelected={selectedId === parent.id}
-                                onClick={() => onSelect(parent.id)}
-                            />
-
-                            {parent.children.map((child) => (
-                                <CategoryPill
-                                    key={child.id}
-                                    category={child}
-                                    isSelected={selectedId === child.id}
-                                    onClick={() => onSelect(child.id)}
-                                />
-                            ))}
-                        </div>
-                    </div>
-                ))
-            ) : (
-                <p className="text-sm text-zinc-500 italic">No categories found. Create one to get started.</p>
-            )}
+        <div className="flex flex-wrap gap-2 max-h-[220px] overflow-y-auto pr-1 custom-scrollbar">
+            {categories.map((cat) => (
+                <CategoryPill
+                    key={cat.id}
+                    category={cat}
+                    isSelected={selectedId === cat.id}
+                    onClick={() => onSelect(cat.id)}
+                />
+            ))}
         </div>
     );
 }
@@ -90,7 +49,7 @@ export function CategorySelector({
 function CategoryPill({
     category,
     isSelected,
-    onClick
+    onClick,
 }: {
     category: Category;
     isSelected: boolean;
@@ -100,15 +59,13 @@ function CategoryPill({
         <button
             type="button"
             onClick={onClick}
-            className={`group relative flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-200 border ${isSelected
+            className={`group relative flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-200 border ${
+                isSelected
                     ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-50 dark:bg-zinc-50 dark:text-zinc-900 scale-105"
                     : "border-zinc-200 bg-white hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300"
-                }`}
+            }`}
         >
-            <span
-                className="w-1.5 h-1.5 rounded-full"
-                style={{ backgroundColor: category.color }}
-            />
+            <CategoryIcon name={category.icon} size={12} style={{ color: isSelected ? undefined : category.color }} />
             {category.name}
             {isSelected && (
                 <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-zinc-900 text-[10px] text-white ring-2 ring-white dark:bg-zinc-50 dark:text-zinc-900 dark:ring-zinc-950">

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { CATEGORY_COLORS } from "@/lib/categories/constants";
+import { Check } from "lucide-react";
+
+interface ColorPickerProps {
+    value: string;
+    onChange: (color: string) => void;
+}
+
+export function ColorPicker({ value, onChange }: ColorPickerProps) {
+    return (
+        <div className="flex flex-wrap gap-2">
+            {CATEGORY_COLORS.map((color) => (
+                <button
+                    key={color}
+                    type="button"
+                    title={color}
+                    onClick={() => onChange(color)}
+                    className="w-7 h-7 rounded-full flex items-center justify-center ring-offset-2 transition-all hover:scale-110"
+                    style={{
+                        backgroundColor: color,
+                        boxShadow: value === color ? `0 0 0 2px white, 0 0 0 4px ${color}` : undefined,
+                    }}
+                >
+                    {value === color && <Check size={12} color="white" strokeWidth={3} />}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/components/DashboardSummary.tsx
+++ b/src/components/DashboardSummary.tsx
@@ -1,5 +1,6 @@
 import { getDashboardSummary } from "@/app/actions/transaction-actions";
 import { BalanceTrendsChart } from "@/components/BalanceTrendsChart";
+import { CategoryIcon } from "@/components/CategoryIcon";
 import { formatCurrency } from "@/lib/format";
 import { ArrowDownRight, ArrowUpRight, Wallet } from "lucide-react";
 import type { ReactNode } from "react";
@@ -131,6 +132,7 @@ interface CategoryBreakdownListProps {
   readonly items: Array<{
     name: string;
     color: string | null;
+    icon: string;
     total: number;
   }>;
 }
@@ -150,13 +152,22 @@ function CategoryBreakdownList({ title, items }: CategoryBreakdownListProps) {
           items.map((item) => {
             const percent = total > 0 ? (item.total / total) * 100 : 0;
             const percentLabel = `${percent.toFixed(1)}%`;
+            const color = item.color || "#9ca3af";
             return (
               <div key={`${title}-${item.name}`} className="group space-y-1">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-zinc-700 dark:text-zinc-200">
-                    {item.name}
+                <div className="flex items-center justify-between text-sm gap-2">
+                  <span className="flex items-center gap-2 min-w-0">
+                    <span
+                      className="flex items-center justify-center w-5 h-5 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: color }}
+                    >
+                      <CategoryIcon name={item.icon} size={11} color="white" />
+                    </span>
+                    <span className="truncate text-zinc-700 dark:text-zinc-200">
+                      {item.name}
+                    </span>
                   </span>
-                  <span className="text-zinc-500 dark:text-zinc-400">
+                  <span className="text-zinc-500 dark:text-zinc-400 flex-shrink-0">
                     {formatCurrency(item.total)}
                   </span>
                 </div>
@@ -166,7 +177,7 @@ function CategoryBreakdownList({ title, items }: CategoryBreakdownListProps) {
                     title={percentLabel}
                     style={{
                       width: `${Math.max(Math.round(percent), 2)}%`,
-                      backgroundColor: item.color || "#9ca3af",
+                      backgroundColor: color,
                     }}
                   />
                 </div>

--- a/src/components/DeleteCategoryDialog.tsx
+++ b/src/components/DeleteCategoryDialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { Category } from "@/types/database";
+import { deleteCategory } from "@/app/actions/category-actions";
+import { Modal } from "./Modal";
+import { OTHERS_NAME } from "@/lib/categories/constants";
+
+interface DeleteCategoryDialogProps {
+    category: Category;
+    transactionCount: number;
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export function DeleteCategoryDialog({
+    category,
+    transactionCount,
+    isOpen,
+    onClose,
+}: DeleteCategoryDialogProps) {
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleDelete() {
+        setIsDeleting(true);
+        setError(null);
+        const result = await deleteCategory(category.id);
+        setIsDeleting(false);
+        if (result.success) {
+            onClose();
+        } else {
+            setError(result.error ?? "Failed to delete category");
+        }
+    }
+
+    const hasTransactions = transactionCount > 0;
+    const willRename = hasTransactions;
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title={`Delete "${category.name}"`}>
+            <div className="space-y-4">
+                {hasTransactions ? (
+                    <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                        This category has <strong>{transactionCount}</strong>{" "}
+                        {transactionCount === 1 ? "transaction" : "transactions"}.{" "}
+                        {willRename ? (
+                            <>
+                                They will be moved to a <strong>&quot;{OTHERS_NAME}&quot;</strong> catch-all category
+                                (created or merged into an existing one).
+                            </>
+                        ) : null}
+                    </p>
+                ) : (
+                    <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                        This category has no transactions and will be permanently deleted.
+                    </p>
+                )}
+
+                {error && (
+                    <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+                )}
+
+                <div className="flex justify-end gap-2 pt-2">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="rounded-md bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700 transition-colors"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleDelete}
+                        disabled={isDeleting}
+                        className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+                    >
+                        {isDeleting ? "Deleting..." : "Delete"}
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,15 +2,15 @@ import Link from 'next/link'
 
 export default function Footer() {
     return (
-        <footer className="border-t border-gray-200 bg-white">
+        <footer className="border-t border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
             <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-                <div className="flex items-center justify-between text-sm text-gray-500">
+                <div className="flex items-center justify-between text-sm text-gray-500 dark:text-zinc-400">
                     <span>© {new Date().getFullYear()} Budget Buddy</span>
                     <div className="flex gap-4">
-                        <Link href="/privacy" className="hover:text-gray-700">
+                        <Link href="/privacy" className="hover:text-gray-700 dark:hover:text-zinc-200">
                             Privacy Policy
                         </Link>
-                        <Link href="/terms" className="hover:text-gray-700">
+                        <Link href="/terms" className="hover:text-gray-700 dark:hover:text-zinc-200">
                             Terms of Service
                         </Link>
                     </div>

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { CATEGORY_ICONS } from "@/lib/categories/constants";
+import { CategoryIcon } from "./CategoryIcon";
+
+interface IconPickerProps {
+    value: string;
+    onChange: (icon: string) => void;
+}
+
+export function IconPicker({ value, onChange }: IconPickerProps) {
+    return (
+        <div className="grid grid-cols-10 gap-1 max-h-40 overflow-y-auto p-1">
+            {CATEGORY_ICONS.map((icon) => (
+                <button
+                    key={icon}
+                    type="button"
+                    title={icon}
+                    onClick={() => onChange(icon)}
+                    className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors ${
+                        value === icon
+                            ? "bg-zinc-900 text-white dark:bg-zinc-50 dark:text-zinc-900"
+                            : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                    }`}
+                >
+                    <CategoryIcon name={icon} size={16} />
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/components/MergeCategoryDialog.tsx
+++ b/src/components/MergeCategoryDialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Category } from "@/types/database";
 import { mergeCategories } from "@/app/actions/category-actions";
 import { Modal } from "./Modal";
+import { CategoryIcon } from "./CategoryIcon";
 
 interface MergeCategoryDialogProps {
     source: Category;
@@ -43,22 +44,30 @@ export function MergeCategoryDialog({
                     the selected category. <strong>&quot;{source.name}&quot;</strong> will then be deleted.
                 </p>
 
-                <div>
-                    <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                        Merge into
-                    </label>
-                    <select
-                        value={targetId}
-                        onChange={(e) => setTargetId(e.target.value)}
-                        className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:focus:border-zinc-500"
-                    >
-                        <option value="">Select a category…</option>
-                        {candidates.map((cat) => (
-                            <option key={cat.id} value={cat.id}>
-                                {cat.name}
-                            </option>
-                        ))}
-                    </select>
+                <div className="space-y-1 max-h-56 overflow-y-auto">
+                    {candidates.map((cat) => (
+                        <button
+                            key={cat.id}
+                            type="button"
+                            onClick={() => setTargetId(cat.id)}
+                            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                                targetId === cat.id
+                                    ? "bg-zinc-900 text-white dark:bg-zinc-50 dark:text-zinc-900"
+                                    : "hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300"
+                            }`}
+                        >
+                            <span
+                                className="flex items-center justify-center w-7 h-7 rounded-full flex-shrink-0"
+                                style={{ backgroundColor: cat.color }}
+                            >
+                                <CategoryIcon name={cat.icon} size={14} color="white" />
+                            </span>
+                            <span className="flex-1 text-left font-medium">{cat.name}</span>
+                            {targetId === cat.id && (
+                                <span className="text-xs opacity-75">selected</span>
+                            )}
+                        </button>
+                    ))}
                 </div>
 
                 {error && (

--- a/src/components/MergeCategoryDialog.tsx
+++ b/src/components/MergeCategoryDialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { Category } from "@/types/database";
+import { mergeCategories } from "@/app/actions/category-actions";
+import { Modal } from "./Modal";
+
+interface MergeCategoryDialogProps {
+    source: Category;
+    candidates: Category[]; // same-type categories, excluding source
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export function MergeCategoryDialog({
+    source,
+    candidates,
+    isOpen,
+    onClose,
+}: MergeCategoryDialogProps) {
+    const [targetId, setTargetId] = useState<string>("");
+    const [isMerging, setIsMerging] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleMerge() {
+        if (!targetId) return;
+        setIsMerging(true);
+        setError(null);
+        const result = await mergeCategories(source.id, targetId);
+        setIsMerging(false);
+        if (result.success) {
+            onClose();
+        } else {
+            setError(result.error ?? "Failed to merge categories");
+        }
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title={`Merge "${source.name}" into…`}>
+            <div className="space-y-4">
+                <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                    All transactions and rules from <strong>&quot;{source.name}&quot;</strong> will move to
+                    the selected category. <strong>&quot;{source.name}&quot;</strong> will then be deleted.
+                </p>
+
+                <div>
+                    <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                        Merge into
+                    </label>
+                    <select
+                        value={targetId}
+                        onChange={(e) => setTargetId(e.target.value)}
+                        className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:focus:border-zinc-500"
+                    >
+                        <option value="">Select a category…</option>
+                        {candidates.map((cat) => (
+                            <option key={cat.id} value={cat.id}>
+                                {cat.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                {error && (
+                    <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+                )}
+
+                <div className="flex justify-end gap-2 pt-2">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="rounded-md bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700 transition-colors"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleMerge}
+                        disabled={isMerging || !targetId}
+                        className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 disabled:opacity-50 transition-colors"
+                    >
+                        {isMerging ? "Merging..." : "Merge"}
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    );
+}

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -13,17 +13,17 @@ export function NavLinks() {
     const pathname = usePathname();
 
     return (
-        <div className="flex items-center gap-1">
+        <div className="flex h-16 items-stretch gap-1">
             {links.map(({ label, href }) => {
                 const isActive = href === "/" ? pathname === "/" : pathname.startsWith(href);
                 return (
                     <Link
                         key={href}
                         href={href}
-                        className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                        className={`flex items-center px-3 text-sm font-medium transition-colors border-b-2 ${
                             isActive
-                                ? "bg-gray-100 text-gray-900"
-                                : "text-gray-500 hover:text-gray-900 hover:bg-gray-50"
+                                ? "border-blue-600 text-blue-600"
+                                : "border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-300"
                         }`}
                     >
                         {label}

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -22,8 +22,8 @@ export function NavLinks() {
                         href={href}
                         className={`flex items-center px-3 text-sm font-medium transition-colors border-b-2 ${
                             isActive
-                                ? "border-blue-600 text-blue-600"
-                                : "border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-300"
+                                ? "border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400"
+                                : "border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-300 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:border-zinc-600"
                         }`}
                     >
                         {label}

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+    { label: "Dashboard", href: "/" },
+    { label: "Transactions", href: "/transactions" },
+    { label: "Categories", href: "/categories" },
+];
+
+export function NavLinks() {
+    const pathname = usePathname();
+
+    return (
+        <div className="flex items-center gap-1">
+            {links.map(({ label, href }) => {
+                const isActive = href === "/" ? pathname === "/" : pathname.startsWith(href);
+                return (
+                    <Link
+                        key={href}
+                        href={href}
+                        className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                            isActive
+                                ? "bg-gray-100 text-gray-900"
+                                : "text-gray-500 hover:text-gray-900 hover:bg-gray-50"
+                        }`}
+                    >
+                        {label}
+                    </Link>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,13 +11,13 @@ export default async function Navbar() {
     } = await supabase.auth.getUser()
 
     return (
-        <nav className="border-b border-gray-200 bg-white">
+        <nav className="border-b border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
             <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                 <div className="flex h-16 justify-between">
                     <div className="flex items-center gap-6">
                         <Link href="/" className="flex flex-shrink-0 items-center gap-2">
                             <Wallet className="h-8 w-8 text-blue-600" />
-                            <span className="text-xl font-bold text-gray-900">Budget Buddy</span>
+                            <span className="text-xl font-bold text-gray-900 dark:text-zinc-50">Budget Buddy</span>
                         </Link>
                         {user && <NavLinks />}
                     </div>
@@ -27,7 +27,7 @@ export default async function Navbar() {
                         ) : (
                             <Link
                                 href="/login"
-                                className="text-sm font-semibold leading-6 text-gray-900 hover:text-blue-600"
+                                className="text-sm font-semibold leading-6 text-gray-900 hover:text-blue-600 dark:text-zinc-50 dark:hover:text-blue-400"
                             >
                                 Log in <span aria-hidden="true">&rarr;</span>
                             </Link>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
 import UserMenu from './UserMenu'
+import { NavLinks } from './NavLinks'
 import { Wallet } from 'lucide-react'
 
 export default async function Navbar() {
@@ -13,13 +14,12 @@ export default async function Navbar() {
         <nav className="border-b border-gray-200 bg-white">
             <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                 <div className="flex h-16 justify-between">
-                    <div className="flex">
-                        <div className="flex flex-shrink-0 items-center">
-                            <Link href="/" className="flex items-center gap-2">
-                                <Wallet className="h-8 w-8 text-blue-600" />
-                                <span className="text-xl font-bold text-gray-900">Budget Buddy</span>
-                            </Link>
-                        </div>
+                    <div className="flex items-center gap-6">
+                        <Link href="/" className="flex flex-shrink-0 items-center gap-2">
+                            <Wallet className="h-8 w-8 text-blue-600" />
+                            <span className="text-xl font-bold text-gray-900">Budget Buddy</span>
+                        </Link>
+                        {user && <NavLinks />}
                     </div>
                     <div className="flex items-center">
                         {user ? (

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -53,6 +53,7 @@ export function TransactionList({ transactions, categories }: TransactionListPro
                   currentCategoryId={transaction.categories?.id || null}
                   currentCategoryName={transaction.categories?.name || "Uncategorized"}
                   currentCategoryColor={transaction.categories?.color || "#9ca3af"}
+                  currentCategoryIcon={transaction.categories?.icon || "circle"}
                   categories={categories.filter(c => c.category_type === transaction.type)}
                 />
               </td>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -38,8 +38,10 @@ export default function UserMenu({ email }: UserMenuProps) {
             </div>
 
             {isOpen && (
+                <>
+                    <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
                 <div
-                    className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                    className="absolute right-0 z-20 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
                     role="menu"
                     aria-orientation="vertical"
                     aria-labelledby="user-menu-button"
@@ -59,6 +61,7 @@ export default function UserMenu({ email }: UserMenuProps) {
                         Sign out
                     </button>
                 </div>
+                </>
             )}
         </div>
     )

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -2,8 +2,7 @@
 
 import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
-import Link from 'next/link'
-import { LogOut, User, Tags } from 'lucide-react'
+import { LogOut, User } from 'lucide-react'
 import { useState } from 'react'
 
 interface UserMenuProps {
@@ -49,16 +48,6 @@ export default function UserMenu({ email }: UserMenuProps) {
                     <div className="px-4 py-2 text-xs text-gray-500 truncate">
                         {email}
                     </div>
-                    <Link
-                        href="/categories"
-                        onClick={() => setIsOpen(false)}
-                        className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                        role="menuitem"
-                        tabIndex={-1}
-                    >
-                        <Tags className="mr-2 h-4 w-4" />
-                        Manage categories
-                    </Link>
                     <button
                         onClick={handleSignOut}
                         className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -24,15 +24,15 @@ export default function UserMenu({ email }: UserMenuProps) {
             <div>
                 <button
                     type="button"
-                    className="flex max-w-xs items-center rounded-full bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                    className="flex max-w-xs items-center rounded-full bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-zinc-950 dark:focus:ring-offset-zinc-950"
                     id="user-menu-button"
                     aria-expanded={isOpen}
                     aria-haspopup="true"
                     onClick={() => setIsOpen(!isOpen)}
                 >
                     <span className="sr-only">Open user menu</span>
-                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100">
-                        <User className="h-5 w-5 text-gray-500" />
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 dark:bg-zinc-800">
+                        <User className="h-5 w-5 text-gray-500 dark:text-zinc-400" />
                     </div>
                 </button>
             </div>
@@ -40,27 +40,27 @@ export default function UserMenu({ email }: UserMenuProps) {
             {isOpen && (
                 <>
                     <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
-                <div
-                    className="absolute right-0 z-20 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
-                    role="menu"
-                    aria-orientation="vertical"
-                    aria-labelledby="user-menu-button"
-                    tabIndex={-1}
-                >
-                    <div className="px-4 py-2 text-xs text-gray-500 truncate">
-                        {email}
-                    </div>
-                    <button
-                        onClick={handleSignOut}
-                        className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                        role="menuitem"
+                    <div
+                        className="absolute right-0 z-20 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-zinc-900 dark:ring-zinc-700"
+                        role="menu"
+                        aria-orientation="vertical"
+                        aria-labelledby="user-menu-button"
                         tabIndex={-1}
-                        id="user-menu-item-2"
                     >
-                        <LogOut className="mr-2 h-4 w-4" />
-                        Sign out
-                    </button>
-                </div>
+                        <div className="px-4 py-2 text-xs text-gray-500 truncate dark:text-zinc-400">
+                            {email}
+                        </div>
+                        <button
+                            onClick={handleSignOut}
+                            className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                            role="menuitem"
+                            tabIndex={-1}
+                            id="user-menu-item-2"
+                        >
+                            <LogOut className="mr-2 h-4 w-4" />
+                            Sign out
+                        </button>
+                    </div>
                 </>
             )}
         </div>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -2,7 +2,8 @@
 
 import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
-import { LogOut, User } from 'lucide-react'
+import Link from 'next/link'
+import { LogOut, User, Tags } from 'lucide-react'
 import { useState } from 'react'
 
 interface UserMenuProps {
@@ -48,6 +49,16 @@ export default function UserMenu({ email }: UserMenuProps) {
                     <div className="px-4 py-2 text-xs text-gray-500 truncate">
                         {email}
                     </div>
+                    <Link
+                        href="/categories"
+                        onClick={() => setIsOpen(false)}
+                        className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                        role="menuitem"
+                        tabIndex={-1}
+                    >
+                        <Tags className="mr-2 h-4 w-4" />
+                        Manage categories
+                    </Link>
                     <button
                         onClick={handleSignOut}
                         className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"

--- a/src/lib/categories/constants.ts
+++ b/src/lib/categories/constants.ts
@@ -1,0 +1,97 @@
+export const CATEGORY_COLORS = [
+  '#ef4444', // red-500
+  '#f97316', // orange-500
+  '#f59e0b', // amber-500
+  '#84cc16', // lime-500
+  '#22c55e', // green-500
+  '#10b981', // emerald-500
+  '#0d9488', // teal-600
+  '#06b6d4', // cyan-500
+  '#3b82f6', // blue-500
+  '#6366f1', // indigo-500
+  '#8b5cf6', // violet-500
+  '#a855f7', // purple-500
+  '#ec4899', // pink-500
+  '#be123c', // rose-700
+  '#7f1d1d', // deep red
+  '#7c2d12', // deep brown
+  '#a16207', // amber-700 mustard
+  '#15803d', // green-700
+  '#0e7490', // cyan-700
+  '#1d4ed8', // blue-700
+  '#4338ca', // indigo-700
+  '#7c3aed', // violet-700
+  '#9333ea', // purple-600
+  '#db2777', // pink-600
+  '#9ca3af', // gray-400
+] as const;
+
+export const CATEGORY_ICONS = [
+  // Finance
+  'wallet',
+  'credit-card',
+  'banknote',
+  'coins',
+  'piggy-bank',
+  'trending-up',
+  'trending-down',
+  'bar-chart-2',
+  'dollar-sign',
+  'receipt',
+  // Shopping
+  'shopping-cart',
+  'shopping-bag',
+  'package',
+  'gift',
+  // Food & Drink
+  'utensils',
+  'coffee',
+  'pizza',
+  'beer',
+  // Transport
+  'car',
+  'bus',
+  'plane',
+  'train-front',
+  'bike',
+  'fuel',
+  // Home
+  'home',
+  'sofa',
+  'lamp',
+  'hammer',
+  'wrench',
+  // Health
+  'heart',
+  'heart-pulse',
+  'pill',
+  'stethoscope',
+  'dumbbell',
+  // Entertainment
+  'music',
+  'film',
+  'gamepad-2',
+  'book',
+  'tv',
+  'headphones',
+  'ticket',
+  // Work & Education
+  'briefcase',
+  'graduation-cap',
+  'laptop',
+  'building-2',
+  'monitor',
+  // Nature
+  'leaf',
+  'sun',
+  'tree-pine',
+  // Communication
+  'smartphone',
+] as const;
+
+export const OTHERS_NAME = 'Others';
+export const OTHERS_COLOR = '#9ca3af';
+export const OTHERS_ICON = 'circle-ellipsis';
+
+export const DEFAULT_NEW_CATEGORY_COLOR = '#3b82f6';
+export const DEFAULT_NEW_CATEGORY_ICON = 'wallet';

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -6,8 +6,7 @@ export interface Category {
     name: string;
     category_type: TransactionType;
     color: string; // hex color code
-    icon: string;  // Lucide icon name
-    parent_id: string | null;
+    icon: string;  // Lucide icon name (kebab-case)
     created_at: string;
 }
 
@@ -15,8 +14,7 @@ export interface CategoryInsert {
     name: string;
     category_type: TransactionType;
     color: string;
-    icon?: string;
-    parent_id?: string | null;
+    icon: string;
 }
 
 export interface Transaction {

--- a/supabase/migrations/20260428_category_management.sql
+++ b/supabase/migrations/20260428_category_management.sql
@@ -1,0 +1,28 @@
+-- =====================================================
+-- Budget Buddy - Category Management Migration
+-- =====================================================
+-- Self-contained. Run independently against any environment.
+
+-- 1. Drop hierarchy index and column
+DROP INDEX IF EXISTS idx_categories_parent_id;
+ALTER TABLE public.categories DROP COLUMN IF EXISTS parent_id;
+
+-- 2. Drop color uniqueness (colors are no longer unique per user)
+ALTER TABLE public.categories
+  DROP CONSTRAINT IF EXISTS categories_user_id_color_key;
+
+-- 3. Replace name uniqueness:
+--    Old: unique per (user_id, name) or (user_id, name, parent_id)
+--    New: unique per (user_id, category_type, name)
+ALTER TABLE public.categories
+  DROP CONSTRAINT IF EXISTS categories_user_id_name_parent_id_key;
+ALTER TABLE public.categories
+  DROP CONSTRAINT IF EXISTS categories_user_id_name_parent_unique;
+ALTER TABLE public.categories
+  DROP CONSTRAINT IF EXISTS categories_user_id_name_key;
+ALTER TABLE public.categories
+  ADD CONSTRAINT IF NOT EXISTS categories_user_id_type_name_key
+  UNIQUE (user_id, category_type, name);
+
+-- 4. Update icon default from 'circle-help' to 'circle'
+ALTER TABLE public.categories ALTER COLUMN icon SET DEFAULT 'circle';


### PR DESCRIPTION
## Summary

- Adds `/categories` page where users can create, edit, delete, and merge categories, each with a chosen icon (50 options) and color (25 options)
- Drops the unused `parent_id` hierarchy from the DB and `CategorySelector` — categories now render as a flat grid per type
- Replaces auto-assigned color palettes with user-chosen color + icon in `createCategory`; adds `updateCategory`, `deleteCategory` (with Others catch-all logic), and `mergeCategories` server actions
- Inline category creation in `AddTransactionForm` now uses the shared `CategoryForm` with icon + color pickers
- Adds "Manage categories" link in `UserMenu`
- Updates `CategoryIcon` to convert kebab-case icon names to PascalCase for lucide-react lookup

Closes #18

## Files changed

**New**
- `supabase/migrations/20260428_category_management.sql` — drops `parent_id`, drops color uniqueness, adds `(user_id, category_type, name)` unique constraint
- `src/lib/categories/constants.ts` — 25 colors, 50 icons, Others defaults
- `src/app/categories/page.tsx` + `CategoryRow.tsx` + `NewCategoryButton.tsx`
- `src/components/IconPicker.tsx`, `ColorPicker.tsx`, `CategoryForm.tsx`
- `src/components/DeleteCategoryDialog.tsx`, `MergeCategoryDialog.tsx`

**Modified**
- `src/app/actions/category-actions.ts` — reworked `createCategory`, added `updateCategory` / `deleteCategory` / `mergeCategories`
- `src/components/CategoryIcon.tsx` — kebab-case → PascalCase conversion
- `src/components/CategorySelector.tsx` — flat grid, no hierarchy
- `src/components/AddTransactionForm.tsx` — uses `CategoryForm` for inline create
- `src/components/UserMenu.tsx` — "Manage categories" link
- `src/types/database.ts` — removed `parent_id`, made `icon` required in `CategoryInsert`

## Test plan

- [ ] Run `supabase/migrations/20260428_category_management.sql` against dev DB; verify `\d categories` shows no `parent_id`, no `(user_id, color)` constraint, and the new `(user_id, category_type, name)` constraint
- [ ] Create a category from `/categories` with chosen icon + color; verify it appears in the right section
- [ ] Edit name, icon, color; verify changes reflected in the New Transaction modal
- [ ] Add transactions to a category, delete it → transactions appear under "Others"
- [ ] Delete a second category with transactions when Others already exists → transactions merged into existing Others, category deleted
- [ ] Merge category A into B → A's transactions under B, A deleted
- [ ] Duplicate name in same type → friendly error; same name across types → allowed
- [ ] New Transaction form: flat category grid, inline create shows icon + color pickers
- [ ] "Manage categories" link in user menu navigates to `/categories`
- [ ] `npm run lint` and `npm run build` clean