### PR TITLE
Client-side cache with fingerprint-based invalidation

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,13 +1,14 @@
-import { test, expect } from '@playwright/test';
-
-test.use({ storageState: { cookies: [], origins: [] } });
+import { test, expect } from './test';
+import { ensureSignedOut } from './helpers/auth';
 
 test('unauthenticated visit to / redirects to /login', async ({ page }) => {
+  await ensureSignedOut(page);
   await page.goto('/');
   await expect(page).toHaveURL(/\/login/);
 });
 
 test('can sign in with email and password', async ({ page }) => {
+  await ensureSignedOut(page);
   await page.goto('/login');
 
   await page.getByText('Sign in with email').click();

--- a/e2e/cache.spec.ts
+++ b/e2e/cache.spec.ts
@@ -41,18 +41,3 @@ test('second visit to transactions page shows content without loading skeleton',
   await expect(page.getByRole('button', { name: 'Newest first' })).toBeVisible();
 });
 
-// Sign-out test must run last — it invalidates the auth session
-test('cache is cleared on sign out', async ({ page }) => {
-  await page.goto('/overview');
-  await expect(page.getByText('Period Balance')).toBeVisible();
-
-  const keysBefore = await page.evaluate(() => Object.keys(localStorage));
-  expect(keysBefore.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(true);
-
-  await page.getByRole('button', { name: /open user menu/i }).click();
-  await page.getByRole('menuitem', { name: /sign out/i }).click();
-  await expect(page).toHaveURL('/login');
-
-  const keysAfter = await page.evaluate(() => Object.keys(localStorage));
-  expect(keysAfter.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(false);
-});

--- a/e2e/cache.spec.ts
+++ b/e2e/cache.spec.ts
@@ -28,21 +28,6 @@ test('range navigation keeps content visible without skeleton flash', async ({ p
   await expect(page.getByText('Changes')).toBeVisible();
 });
 
-test('cache is cleared on sign out', async ({ page }) => {
-  await page.goto('/overview');
-  await expect(page.getByText('Period Balance')).toBeVisible();
-
-  const keysBefore = await page.evaluate(() => Object.keys(localStorage));
-  expect(keysBefore.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(true);
-
-  await page.getByRole('button', { name: /open user menu/i }).click();
-  await page.getByRole('button', { name: /sign out/i }).click();
-  await expect(page).toHaveURL('/login');
-
-  const keysAfter = await page.evaluate(() => Object.keys(localStorage));
-  expect(keysAfter.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(false);
-});
-
 test('second visit to transactions page shows content without loading skeleton', async ({ page }) => {
   // Seed the cache
   await page.goto('/overview');
@@ -54,4 +39,20 @@ test('second visit to transactions page shows content without loading skeleton',
   // Content should appear without remaining on a skeleton
   await expect(page.getByRole('button', { name: 'Add Transaction' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Newest first' })).toBeVisible();
+});
+
+// Sign-out test must run last — it invalidates the auth session
+test('cache is cleared on sign out', async ({ page }) => {
+  await page.goto('/overview');
+  await expect(page.getByText('Period Balance')).toBeVisible();
+
+  const keysBefore = await page.evaluate(() => Object.keys(localStorage));
+  expect(keysBefore.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(true);
+
+  await page.getByRole('button', { name: /open user menu/i }).click();
+  await page.getByRole('menuitem', { name: /sign out/i }).click();
+  await expect(page).toHaveURL('/login');
+
+  const keysAfter = await page.evaluate(() => Object.keys(localStorage));
+  expect(keysAfter.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(false);
 });

--- a/e2e/cache.spec.ts
+++ b/e2e/cache.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 
 test('localStorage cache is populated after first load', async ({ page }) => {
   await page.goto('/overview');

--- a/e2e/cache.spec.ts
+++ b/e2e/cache.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+test('localStorage cache is populated after first load', async ({ page }) => {
+  await page.goto('/overview');
+  await expect(page.getByText('Period Balance')).toBeVisible();
+
+  const keys = await page.evaluate(() => Object.keys(localStorage));
+  const cacheKey = keys.find((k) => k.startsWith('budget-buddy:cache:'));
+  expect(cacheKey).toBeDefined();
+
+  const raw = await page.evaluate((k) => localStorage.getItem(k!), cacheKey);
+  const parsed = JSON.parse(raw!);
+  expect(parsed).toHaveProperty('transactions');
+  expect(parsed).toHaveProperty('categories');
+  expect(parsed).toHaveProperty('fingerprint');
+});
+
+test('range navigation keeps content visible without skeleton flash', async ({ page }) => {
+  await page.goto('/overview');
+  await expect(page.getByText('Period Balance')).toBeVisible();
+
+  // Navigate to previous period — client-side re-render from cache, not a server fetch
+  await page.getByRole('button', { name: 'Go to previous period' }).click();
+  await expect(page).toHaveURL(/[?&]from=\d{4}-\d{2}-\d{2}/);
+
+  // Charts must remain visible immediately — no skeleton means no full reload
+  await expect(page.getByText('Period Balance')).toBeVisible();
+  await expect(page.getByText('Changes')).toBeVisible();
+});
+
+test('cache is cleared on sign out', async ({ page }) => {
+  await page.goto('/overview');
+  await expect(page.getByText('Period Balance')).toBeVisible();
+
+  const keysBefore = await page.evaluate(() => Object.keys(localStorage));
+  expect(keysBefore.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(true);
+
+  await page.getByRole('button', { name: /open user menu/i }).click();
+  await page.getByRole('button', { name: /sign out/i }).click();
+  await expect(page).toHaveURL('/login');
+
+  const keysAfter = await page.evaluate(() => Object.keys(localStorage));
+  expect(keysAfter.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(false);
+});
+
+test('second visit to transactions page shows content without loading skeleton', async ({ page }) => {
+  // Seed the cache
+  await page.goto('/overview');
+  await expect(page.getByText('Period Balance')).toBeVisible();
+
+  // Navigate to transactions — DataProvider re-mounts but should hit localStorage
+  await page.goto('/transactions');
+
+  // Content should appear without remaining on a skeleton
+  await expect(page.getByRole('button', { name: 'Add Transaction' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Newest first' })).toBeVisible();
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 
 test('overview renders chart widgets', async ({ page }) => {
   await page.goto('/overview');

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+
+async function signIn(page: Page) {
+  await page.getByText('Sign in with email').click();
+  await page.getByLabel('Email').fill(process.env.TEST_USER_EMAIL!);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD!);
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+  await page.waitForURL('/');
+}
+
+export async function ensureSignedIn(page: Page) {
+  await page.goto('/');
+  if (page.url().includes('/login')) {
+    await signIn(page);
+  }
+}
+
+export async function ensureSignedOut(page: Page) {
+  await page.goto('/');
+  if (!page.url().includes('/login')) {
+    await page.getByRole('button', { name: /open user menu/i }).click();
+    await page.getByRole('menuitem', { name: /sign out/i }).click();
+    await page.waitForURL('/login');
+  }
+}

--- a/e2e/overview.spec.ts
+++ b/e2e/overview.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 
 test('overview loads all four chart widgets', async ({ page }) => {
   await page.goto('/overview');

--- a/e2e/signout.spec.ts
+++ b/e2e/signout.spec.ts
@@ -1,7 +1,4 @@
-// This file is named z_signout.spec.ts so it runs last alphabetically.
-// The sign-out call invalidates the Supabase access token in the shared auth state,
-// which would break any tests that run after it in the same process.
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 
 test('cache is cleared on sign out', async ({ page }) => {
   await page.goto('/overview');

--- a/e2e/static-pages.spec.ts
+++ b/e2e/static-pages.spec.ts
@@ -1,6 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
+import { ensureSignedOut } from './helpers/auth';
 
-test.use({ storageState: { cookies: [], origins: [] } });
+test.beforeEach(async ({ page }) => {
+  await ensureSignedOut(page);
+});
 
 test('/privacy is reachable without auth', async ({ page }) => {
   await page.goto('/privacy');

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -1,0 +1,11 @@
+import { test as base, expect } from '@playwright/test';
+import { ensureSignedIn } from './helpers/auth';
+
+export { expect };
+
+export const test = base.extend<object>({
+  page: async ({ page }, use) => {
+    await ensureSignedIn(page);
+    await use(page);
+  },
+});

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { addTransaction } from './helpers/transactions';
 
 test('can add a transaction', async ({ page }) => {

--- a/e2e/z_signout.spec.ts
+++ b/e2e/z_signout.spec.ts
@@ -1,0 +1,19 @@
+// This file is named z_signout.spec.ts so it runs last alphabetically.
+// The sign-out call invalidates the Supabase access token in the shared auth state,
+// which would break any tests that run after it in the same process.
+import { test, expect } from '@playwright/test';
+
+test('cache is cleared on sign out', async ({ page }) => {
+  await page.goto('/overview');
+  await expect(page.getByText('Period Balance')).toBeVisible();
+
+  const keysBefore = await page.evaluate(() => Object.keys(localStorage));
+  expect(keysBefore.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(true);
+
+  await page.getByRole('button', { name: /open user menu/i }).click();
+  await page.getByRole('menuitem', { name: /sign out/i }).click();
+  await expect(page).toHaveURL('/login');
+
+  const keysAfter = await page.evaluate(() => Object.keys(localStorage));
+  expect(keysAfter.some((k) => k.startsWith('budget-buddy:cache:'))).toBe(false);
+});

--- a/src/app/actions/data-actions.ts
+++ b/src/app/actions/data-actions.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { Category, TransactionWithCategory } from "@/types/database";
+
+type RawTransactionRow = Omit<TransactionWithCategory, "categories"> & {
+  categories: Category | Category[] | null;
+};
+
+interface FingerprintResult {
+  success: boolean;
+  fingerprint?: string;
+  error?: string;
+}
+
+interface AllDataResult {
+  success: boolean;
+  data?: {
+    transactions: TransactionWithCategory[];
+    categories: Category[];
+    fingerprint: string;
+  };
+  error?: string;
+}
+
+export async function getFingerprint(): Promise<FingerprintResult> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "User not authenticated" };
+
+    const [txResult, catResult] = await Promise.all([
+      supabase
+        .from("transactions")
+        .select("updated_at", { count: "exact" })
+        .eq("user_id", user.id)
+        .order("updated_at", { ascending: false })
+        .limit(1),
+      supabase
+        .from("categories")
+        .select("updated_at", { count: "exact" })
+        .eq("user_id", user.id)
+        .order("updated_at", { ascending: false })
+        .limit(1),
+    ]);
+
+    if (txResult.error) return { success: false, error: txResult.error.message };
+    if (catResult.error) return { success: false, error: catResult.error.message };
+
+    const txMax = txResult.data?.[0]?.updated_at ?? "0";
+    const catMax = catResult.data?.[0]?.updated_at ?? "0";
+    const txCount = txResult.count ?? 0;
+    const catCount = catResult.count ?? 0;
+
+    return {
+      success: true,
+      fingerprint: `tx:${txCount}:${txMax}|cat:${catCount}:${catMax}`,
+    };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Unknown error" };
+  }
+}
+
+export async function getAllData(): Promise<AllDataResult> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "User not authenticated" };
+
+    const [txResult, catResult] = await Promise.all([
+      supabase
+        .from("transactions")
+        .select("*, categories(*)", { count: "exact" })
+        .eq("user_id", user.id)
+        .order("date", { ascending: false })
+        .limit(1000),
+      supabase
+        .from("categories")
+        .select("*", { count: "exact" })
+        .eq("user_id", user.id)
+        .order("name", { ascending: true }),
+    ]);
+
+    if (txResult.error) return { success: false, error: txResult.error.message };
+    if (catResult.error) return { success: false, error: catResult.error.message };
+
+    const transactions: TransactionWithCategory[] = (txResult.data || []).map(
+      (t: RawTransactionRow) => ({
+        ...t,
+        categories: Array.isArray(t.categories) ? t.categories[0] : t.categories,
+      })
+    );
+
+    const categories = catResult.data as Category[];
+
+    // Compute fingerprint from the fetched data — avoids an extra round-trip
+    const txMax = transactions.reduce((m, t) => (t.updated_at > m ? t.updated_at : m), "0");
+    const catMax = categories.reduce((m, c) => (c.updated_at > m ? c.updated_at : m), "0");
+    const fingerprint = `tx:${txResult.count ?? 0}:${txMax}|cat:${catResult.count ?? 0}:${catMax}`;
+
+    return {
+      success: true,
+      data: { transactions, categories, fingerprint },
+    };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Unknown error" };
+  }
+}

--- a/src/app/actions/learning-actions.ts
+++ b/src/app/actions/learning-actions.ts
@@ -3,6 +3,11 @@
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { normalizeDescription } from "@/lib/categorization/engine";
+import { Category, TransactionWithCategory } from "@/types/database";
+
+type RawTransactionRow = Omit<TransactionWithCategory, "categories"> & {
+  categories: Category | Category[] | null;
+};
 
 export async function updateTransactionCategory(transactionId: string, categoryId: string) {
     const supabase = await createClient();
@@ -27,11 +32,13 @@ export async function updateTransactionCategory(transactionId: string, categoryI
         return { success: false, error: "Unauthorized" };
     }
 
-    // 2. Update the transaction
-    const { error: updateError } = await supabase
+    // 2. Update the transaction and return the updated row with category joined
+    const { data: updatedRow, error: updateError } = await supabase
         .from('transactions')
         .update({ category_id: categoryId })
-        .eq('id', transactionId);
+        .eq('id', transactionId)
+        .select('*, categories(*)')
+        .single();
 
     if (updateError) {
         return { success: false, error: updateError.message };
@@ -54,7 +61,13 @@ export async function updateTransactionCategory(transactionId: string, categoryI
         }
     }
 
+    const raw = updatedRow as RawTransactionRow;
+    const normalized: TransactionWithCategory = {
+        ...raw,
+        categories: Array.isArray(raw.categories) ? raw.categories[0] : raw.categories,
+    };
+
     revalidatePath('/transactions');
     revalidatePath('/overview');
-    return { success: true };
+    return { success: true, data: normalized };
 }

--- a/src/app/actions/transaction-actions.ts
+++ b/src/app/actions/transaction-actions.ts
@@ -14,8 +14,15 @@ interface GetTransactionsResult {
   error?: string;
 }
 
-interface ActionResult {
+interface AddTransactionResult {
   success: boolean;
+  data?: TransactionWithCategory;
+  error?: string;
+}
+
+interface DeleteTransactionResult {
+  success: boolean;
+  data?: { id: string };
   error?: string;
 }
 
@@ -68,7 +75,7 @@ export async function getTransactionsByRange(
 
 export async function addTransaction(
   transaction: TransactionInsert
-): Promise<ActionResult> {
+): Promise<AddTransactionResult> {
   try {
     if (!transaction.amount || transaction.amount <= 0) {
       return { success: false, error: "Amount must be greater than 0" };
@@ -95,23 +102,33 @@ export async function addTransaction(
       return { success: false, error: "User not authenticated" };
     }
 
-    const { error } = await supabase.from("transactions").insert({
-      amount: transaction.amount,
-      type: transaction.type,
-      category_id: transaction.category_id,
-      description: transaction.description?.trim() || null,
-      date: transaction.date,
-      user_id: user.id,
-    });
+    const { data, error } = await supabase
+      .from("transactions")
+      .insert({
+        amount: transaction.amount,
+        type: transaction.type,
+        category_id: transaction.category_id,
+        description: transaction.description?.trim() || null,
+        date: transaction.date,
+        user_id: user.id,
+      })
+      .select("*, categories(*)")
+      .single();
 
     if (error) {
       return { success: false, error: error.message };
     }
 
+    const row = data as RawTransactionRow;
+    const normalized: TransactionWithCategory = {
+      ...row,
+      categories: Array.isArray(row.categories) ? row.categories[0] : row.categories,
+    };
+
     revalidatePath("/transactions");
     revalidatePath("/overview");
 
-    return { success: true };
+    return { success: true, data: normalized };
   } catch (error) {
     return {
       success: false,
@@ -120,7 +137,7 @@ export async function addTransaction(
   }
 }
 
-export async function deleteTransaction(id: string): Promise<ActionResult> {
+export async function deleteTransaction(id: string): Promise<DeleteTransactionResult> {
   try {
     if (!id || id.trim() === "") {
       return { success: false, error: "Transaction ID is required" };
@@ -148,7 +165,7 @@ export async function deleteTransaction(id: string): Promise<ActionResult> {
     revalidatePath("/transactions");
     revalidatePath("/overview");
 
-    return { success: true };
+    return { success: true, data: { id } };
   } catch (error) {
     return {
       success: false,

--- a/src/app/overview/OverviewClientContent.tsx
+++ b/src/app/overview/OverviewClientContent.tsx
@@ -1,32 +1,30 @@
-import { getOverviewData } from "@/app/actions/overview-actions";
+"use client";
+
+import { useData } from "@/providers/DataProvider";
+import { computeOverviewData } from "@/lib/compute";
 import { PeriodBalanceChart } from "@/components/overview/PeriodBalanceChart";
 import { ChangesChart } from "@/components/overview/ChangesChart";
 import { PeriodCategoryWidget } from "@/components/overview/PeriodCategoryWidget";
 
-interface OverviewContentProps {
-  start: string;
-  end: string;
+interface OverviewClientContentProps {
+  from: string;
+  to: string;
 }
 
-export async function OverviewContent({ start, end }: OverviewContentProps) {
-  const result = await getOverviewData(start, end);
+export function OverviewClientContent({ from, to }: OverviewClientContentProps) {
+  const { transactions, status } = useData();
+  const data = computeOverviewData(transactions, from, to);
 
-  if (!result.success || !result.data) {
-    return (
-      <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-sm text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
-        Failed to load overview data.
-      </div>
-    );
+  if (status === "loading") {
+    return <OverviewSkeleton />;
   }
-
-  const { transactions, categoryBreakdown } = result.data;
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-      <PeriodBalanceChart transactions={transactions} from={start} to={end} />
-      <ChangesChart transactions={transactions} from={start} to={end} />
-      <PeriodCategoryWidget type="income" categoryBreakdown={categoryBreakdown} from={start} to={end} />
-      <PeriodCategoryWidget type="expense" categoryBreakdown={categoryBreakdown} from={start} to={end} />
+      <PeriodBalanceChart transactions={data.transactions} from={from} to={to} />
+      <ChangesChart transactions={data.transactions} from={from} to={to} />
+      <PeriodCategoryWidget type="income" categoryBreakdown={data.categoryBreakdown} from={from} to={to} />
+      <PeriodCategoryWidget type="expense" categoryBreakdown={data.categoryBreakdown} from={from} to={to} />
     </div>
   );
 }

--- a/src/app/overview/page.tsx
+++ b/src/app/overview/page.tsx
@@ -1,8 +1,8 @@
-import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { DateRangeNav } from "@/components/DateRangeNav";
-import { OverviewContent, OverviewSkeleton } from "./OverviewContent";
+import { OverviewClientContent } from "./OverviewClientContent";
+import { DataProvider } from "@/providers/DataProvider";
 import { toISODate } from "@/lib/format";
 
 function defaultRange(): { from: Date; to: Date } {
@@ -35,8 +35,6 @@ export default async function OverviewPage({
   const start = toISODate(fromDate);
   const end = toISODate(toDate);
 
-  const contentKey = `${start}-${end}`;
-
   return (
     <div className="min-h-screen bg-zinc-50 font-sans dark:bg-black">
       <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
@@ -44,9 +42,9 @@ export default async function OverviewPage({
           <DateRangeNav from={fromDate} to={toDate} />
         </div>
 
-        <Suspense key={contentKey} fallback={<OverviewSkeleton />}>
-          <OverviewContent start={start} end={end} />
-        </Suspense>
+        <DataProvider userId={user.id}>
+          <OverviewClientContent from={start} to={end} />
+        </DataProvider>
       </main>
     </div>
   );

--- a/src/app/transactions/TransactionsClientContent.tsx
+++ b/src/app/transactions/TransactionsClientContent.tsx
@@ -1,42 +1,16 @@
 "use client";
 
 import { useData } from "@/providers/DataProvider";
-import { filterByRange } from "@/lib/compute";
 import { TransactionFilters } from "@/components/transactions/TransactionFilters";
 
-interface TransactionsClientContentProps {
-  start: string;
-  end: string;
-  fromDate: Date;
-  toDate: Date;
-}
-
-export function TransactionsClientContent({
-  start,
-  end,
-  fromDate,
-  toDate,
-}: TransactionsClientContentProps) {
+export function TransactionsClientContent() {
   const { transactions, categories, status } = useData();
-
-  const rangeFiltered = filterByRange(transactions, start, end);
-
-  const amounts = rangeFiltered.map((t) => t.amount);
-  const amountMax = amounts.length ? Math.max(...amounts) : 0;
 
   if (status === "loading") {
     return <TransactionsSkeleton />;
   }
 
-  return (
-    <TransactionFilters
-      categories={categories}
-      allTransactions={rangeFiltered}
-      initialFrom={fromDate}
-      initialTo={toDate}
-      amountMax={amountMax}
-    />
-  );
+  return <TransactionFilters categories={categories} allTransactions={transactions} />;
 }
 
 export function TransactionsSkeleton() {

--- a/src/app/transactions/TransactionsClientContent.tsx
+++ b/src/app/transactions/TransactionsClientContent.tsx
@@ -7,8 +7,6 @@ import { TransactionFilters } from "@/components/transactions/TransactionFilters
 interface TransactionsClientContentProps {
   start: string;
   end: string;
-  categoryIds: string[];
-  sort: "asc" | "desc";
   fromDate: Date;
   toDate: Date;
 }
@@ -16,8 +14,6 @@ interface TransactionsClientContentProps {
 export function TransactionsClientContent({
   start,
   end,
-  categoryIds,
-  sort,
   fromDate,
   toDate,
 }: TransactionsClientContentProps) {
@@ -26,7 +22,6 @@ export function TransactionsClientContent({
   const rangeFiltered = filterByRange(transactions, start, end);
 
   const amounts = rangeFiltered.map((t) => t.amount);
-  const amountMin = amounts.length ? Math.min(...amounts) : 0;
   const amountMax = amounts.length ? Math.max(...amounts) : 0;
 
   if (status === "loading") {
@@ -39,9 +34,6 @@ export function TransactionsClientContent({
       allTransactions={rangeFiltered}
       initialFrom={fromDate}
       initialTo={toDate}
-      initialSelectedCategories={categoryIds}
-      initialSort={sort}
-      amountMin={amountMin}
       amountMax={amountMax}
     />
   );

--- a/src/app/transactions/TransactionsClientContent.tsx
+++ b/src/app/transactions/TransactionsClientContent.tsx
@@ -1,8 +1,10 @@
-import { getTransactionsByRange } from "@/app/actions/transaction-actions";
-import { getCategories } from "@/app/actions/category-actions";
+"use client";
+
+import { useData } from "@/providers/DataProvider";
+import { filterByRange } from "@/lib/compute";
 import { TransactionFilters } from "@/components/transactions/TransactionFilters";
 
-interface TransactionsContentProps {
+interface TransactionsClientContentProps {
   start: string;
   end: string;
   categoryIds: string[];
@@ -11,30 +13,30 @@ interface TransactionsContentProps {
   toDate: Date;
 }
 
-export async function TransactionsContent({
+export function TransactionsClientContent({
   start,
   end,
   categoryIds,
   sort,
   fromDate,
   toDate,
-}: TransactionsContentProps) {
-  const [txResult, catResult] = await Promise.all([
-    getTransactionsByRange(start, end, { categoryIds: categoryIds.length ? categoryIds : undefined, sort }),
-    getCategories(),
-  ]);
+}: TransactionsClientContentProps) {
+  const { transactions, categories, status } = useData();
 
-  const transactions = txResult.data ?? [];
-  const categories = catResult.data ?? [];
+  const rangeFiltered = filterByRange(transactions, start, end);
 
-  const amounts = transactions.map((t) => t.amount);
+  const amounts = rangeFiltered.map((t) => t.amount);
   const amountMin = amounts.length ? Math.min(...amounts) : 0;
   const amountMax = amounts.length ? Math.max(...amounts) : 0;
+
+  if (status === "loading") {
+    return <TransactionsSkeleton />;
+  }
 
   return (
     <TransactionFilters
       categories={categories}
-      allTransactions={transactions}
+      allTransactions={rangeFiltered}
       initialFrom={fromDate}
       initialTo={toDate}
       initialSelectedCategories={categoryIds}

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -4,37 +4,11 @@ import { AddTransactionButton } from "@/components/AddTransactionButton";
 import { ImportTransactionsButton } from "@/components/ImportTransactionsButton";
 import { TransactionsClientContent } from "./TransactionsClientContent";
 import { DataProvider } from "@/providers/DataProvider";
-import { toISODate } from "@/lib/format";
 
-function defaultRange(): { from: Date; to: Date } {
-  const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth(), 1);
-  const to = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-  return { from, to };
-}
-
-function parseDate(s: string | undefined, fallback: Date): Date {
-  if (!s) return fallback;
-  const d = new Date(s + "T00:00:00");
-  return isNaN(d.getTime()) ? fallback : d;
-}
-
-export default async function TransactionsPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ from?: string; to?: string }>;
-}) {
+export default async function TransactionsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/login");
-
-  const params = await searchParams;
-  const defaults = defaultRange();
-
-  const fromDate = parseDate(params.from, defaults.from);
-  const toDate = parseDate(params.to, defaults.to);
-  const start = toISODate(fromDate);
-  const end = toISODate(toDate);
 
   return (
     <div className="min-h-screen bg-zinc-50 font-sans dark:bg-black">
@@ -50,12 +24,7 @@ export default async function TransactionsPage({
             </div>
           </header>
 
-          <TransactionsClientContent
-            start={start}
-            end={end}
-            fromDate={fromDate}
-            toDate={toDate}
-          />
+          <TransactionsClientContent />
         </DataProvider>
       </main>
     </div>

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -22,7 +22,7 @@ function parseDate(s: string | undefined, fallback: Date): Date {
 export default async function TransactionsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ from?: string; to?: string; categories?: string; sort?: string }>;
+  searchParams: Promise<{ from?: string; to?: string }>;
 }) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -35,13 +35,6 @@ export default async function TransactionsPage({
   const toDate = parseDate(params.to, defaults.to);
   const start = toISODate(fromDate);
   const end = toISODate(toDate);
-
-  const categoryIds = params.categories
-    ? params.categories.split(",").filter(Boolean)
-    : [];
-
-  const sort: "asc" | "desc" =
-    params.sort === "asc" ? "asc" : "desc";
 
   return (
     <div className="min-h-screen bg-zinc-50 font-sans dark:bg-black">
@@ -60,8 +53,6 @@ export default async function TransactionsPage({
           <TransactionsClientContent
             start={start}
             end={end}
-            categoryIds={categoryIds}
-            sort={sort}
             fromDate={fromDate}
             toDate={toDate}
           />

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,9 +1,9 @@
-import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { AddTransactionButton } from "@/components/AddTransactionButton";
 import { ImportTransactionsButton } from "@/components/ImportTransactionsButton";
-import { TransactionsContent, TransactionsSkeleton } from "./TransactionsContent";
+import { TransactionsClientContent } from "./TransactionsClientContent";
+import { DataProvider } from "@/providers/DataProvider";
 import { toISODate } from "@/lib/format";
 
 function defaultRange(): { from: Date; to: Date } {
@@ -43,23 +43,21 @@ export default async function TransactionsPage({
   const sort: "asc" | "desc" =
     params.sort === "asc" ? "asc" : "desc";
 
-  const contentKey = `${start}-${end}-${categoryIds.join(",")}-${sort}`;
-
   return (
     <div className="min-h-screen bg-zinc-50 font-sans dark:bg-black">
       <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
-        <header className="mb-6 flex items-center justify-between">
-          <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-            Transactions
-          </h1>
-          <div className="flex items-center gap-2">
-            <AddTransactionButton />
-            <ImportTransactionsButton />
-          </div>
-        </header>
+        <DataProvider userId={user.id}>
+          <header className="mb-6 flex items-center justify-between">
+            <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+              Transactions
+            </h1>
+            <div className="flex items-center gap-2">
+              <AddTransactionButton />
+              <ImportTransactionsButton />
+            </div>
+          </header>
 
-        <Suspense key={contentKey} fallback={<TransactionsSkeleton />}>
-          <TransactionsContent
+          <TransactionsClientContent
             start={start}
             end={end}
             categoryIds={categoryIds}
@@ -67,7 +65,7 @@ export default async function TransactionsPage({
             fromDate={fromDate}
             toDate={toDate}
           />
-        </Suspense>
+        </DataProvider>
       </main>
     </div>
   );

--- a/src/components/AddTransactionForm.tsx
+++ b/src/components/AddTransactionForm.tsx
@@ -1,45 +1,32 @@
 "use client";
 
 import { addTransaction } from "@/app/actions/transaction-actions";
-import { getCategories, createCategory } from "@/app/actions/category-actions";
-import { TransactionType, Category } from "@/types/database";
-import { useState, useEffect } from "react";
+import { createCategory } from "@/app/actions/category-actions";
+import { TransactionType } from "@/types/database";
+import { useState } from "react";
 import { CategorySelector } from "./CategorySelector";
 import { CategoryForm } from "./CategoryForm";
+import { useData } from "@/providers/DataProvider";
 
 interface AddTransactionFormProps {
   onSuccess?: () => void;
 }
 
 export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
+  const { categories: allCategories, applyTransaction, invalidateAndRefetch, status } = useData();
   const [amount, setAmount] = useState("");
   const [type, setType] = useState<TransactionType>("expense");
   const [categoryId, setCategoryId] = useState("");
   const [isCreatingCategory, setIsCreatingCategory] = useState(false);
-  const [allCategories, setAllCategories] = useState<Category[]>([]);
   const [description, setDescription] = useState("");
   const [date, setDate] = useState(getTodayDate());
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isLoadingCategories, setIsLoadingCategories] = useState(true);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
   const [isCreatingSubmitting, setIsCreatingSubmitting] = useState(false);
 
   // Filter categories locally based on the selected type
   const categories = allCategories.filter((cat) => cat.category_type === type);
-
-  // Fetch all categories once when the form mounts
-  useEffect(() => {
-    async function loadCategories() {
-      setIsLoadingCategories(true);
-      const result = await getCategories();
-      if (result.success && result.data) {
-        setAllCategories(result.data);
-      }
-      setIsLoadingCategories(false);
-    }
-    loadCategories();
-  }, []);
 
   async function handleCreateCategory(data: {
     name: string;
@@ -53,9 +40,9 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
     setIsCreatingSubmitting(false);
 
     if (result.success && result.data) {
-      setAllCategories([...allCategories, result.data]);
       setCategoryId(result.data.id);
       setIsCreatingCategory(false);
+      invalidateAndRefetch(); // new category must appear in DataProvider's categories list
     } else {
       setCreateError(result.error ?? "Failed to create category");
     }
@@ -83,7 +70,8 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
 
     setIsSubmitting(false);
 
-    if (result.success) {
+    if (result.success && result.data) {
+      applyTransaction({ op: "add", transaction: result.data });
       setMessage({ type: "success", text: "Transaction added successfully!" });
       setAmount("");
       setCategoryId("");
@@ -210,7 +198,7 @@ export function AddTransactionForm({ onSuccess }: AddTransactionFormProps) {
                 categories={categories}
                 selectedId={categoryId}
                 onSelect={(id: string) => setCategoryId(id)}
-                isLoading={isLoadingCategories}
+                isLoading={status === "loading"}
               />
             )}
           </div>

--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -5,6 +5,7 @@ import { Category } from "@/types/database";
 import { updateTransactionCategory } from "@/app/actions/learning-actions";
 import { Check, ChevronDown, Loader2 } from "lucide-react";
 import { CategoryIcon } from "./CategoryIcon";
+import { useData } from "@/providers/DataProvider";
 
 interface CategoryPickerProps {
     transactionId: string;
@@ -23,6 +24,7 @@ export function CategoryPicker({
     currentCategoryIcon,
     categories
 }: CategoryPickerProps) {
+    const { applyTransaction } = useData();
     const [isOpen, setIsOpen] = useState(false);
     const [isUpdating, setIsUpdating] = useState(false);
     const [openUpward, setOpenUpward] = useState(false);
@@ -39,7 +41,9 @@ export function CategoryPicker({
         setIsUpdating(false);
         setIsOpen(false);
 
-        if (!result.success) {
+        if (result.success && result.data) {
+            applyTransaction({ op: "update", transaction: result.data });
+        } else if (!result.success) {
             alert(result.error || "Failed to update category");
         }
     }

--- a/src/components/DeleteTransactionButton.tsx
+++ b/src/components/DeleteTransactionButton.tsx
@@ -3,33 +3,33 @@
 import { deleteTransaction } from "@/app/actions/transaction-actions";
 import { Trash2 } from "lucide-react";
 import { useState } from "react";
+import { useData } from "@/providers/DataProvider";
 
 interface DeleteTransactionButtonProps {
   readonly id: string;
 }
 
 export function DeleteTransactionButton({ id }: DeleteTransactionButtonProps) {
+  const { applyTransaction } = useData();
   const [isDeleting, setIsDeleting] = useState(false);
 
   async function handleDelete() {
-    // Confirmation dialog
     const confirmed = globalThis.confirm(
       "Are you sure you want to delete this transaction? This action cannot be undone."
     );
 
-    if (!confirmed) {
-      return;
-    }
+    if (!confirmed) return;
 
     setIsDeleting(true);
 
     const result = await deleteTransaction(id);
 
-    if (!result.success) {
+    if (result.success) {
+      applyTransaction({ op: "delete", id });
+    } else {
       alert(`Failed to delete transaction: ${result.error}`);
-      setIsDeleting(false);
     }
-    // No need to reset isDeleting on success since the component will unmount
+    setIsDeleting(false);
   }
 
   return (

--- a/src/components/ImportTransactionsButton.tsx
+++ b/src/components/ImportTransactionsButton.tsx
@@ -4,9 +4,16 @@ import { useState } from "react";
 import { Download } from "lucide-react";
 import { Modal } from "./Modal";
 import { ImportTransactionsForm } from "./ImportTransactionsForm";
+import { useData } from "@/providers/DataProvider";
 
 export function ImportTransactionsButton() {
+    const { invalidateAndRefetch } = useData();
     const [isOpen, setIsOpen] = useState(false);
+
+    async function handleSuccess() {
+        await invalidateAndRefetch();
+        setIsOpen(false);
+    }
 
     return (
         <>
@@ -24,7 +31,7 @@ export function ImportTransactionsButton() {
                 onClose={() => setIsOpen(false)}
                 title="Import Transactions"
             >
-                <ImportTransactionsForm onSuccess={() => setIsOpen(false)} />
+                <ImportTransactionsForm onSuccess={handleSuccess} />
             </Modal>
         </>
     );

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 import { LogOut, User } from 'lucide-react'
 import { useState } from 'react'
+import { clearAllCaches } from '@/lib/client-cache'
 
 interface UserMenuProps {
     email: string
@@ -15,6 +16,7 @@ export default function UserMenu({ email }: UserMenuProps) {
     const [isOpen, setIsOpen] = useState(false)
 
     const handleSignOut = async () => {
+        clearAllCaches()
         await supabase.auth.signOut()
         router.refresh()
     }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -17,7 +17,7 @@ export default function UserMenu({ email }: UserMenuProps) {
 
     const handleSignOut = async () => {
         clearAllCaches()
-        await supabase.auth.signOut()
+        await supabase.auth.signOut({ scope: 'local' })
         router.refresh()
     }
 

--- a/src/components/transactions/TransactionFilters.tsx
+++ b/src/components/transactions/TransactionFilters.tsx
@@ -1,71 +1,89 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { ArrowUpDown } from "lucide-react";
 import { Category, TransactionWithCategory } from "@/types/database";
 import { DateRangePicker, DateRange } from "@/components/DateRangePicker";
 import { AmountRangeSlider } from "./AmountRangeSlider";
 import { CategoryMultiSelect } from "./CategoryMultiSelect";
 import { TransactionList } from "@/components/TransactionList";
+import { filterByRange } from "@/lib/compute";
 import { toISODate } from "@/lib/format";
+
+function defaultDateRange() {
+  const now = new Date();
+  return {
+    from: new Date(now.getFullYear(), now.getMonth(), 1),
+    to: new Date(now.getFullYear(), now.getMonth() + 1, 0),
+  };
+}
+
+function parseDate(s: string | null, fallback: Date): Date {
+  if (!s) return fallback;
+  const d = new Date(s + "T00:00:00");
+  return isNaN(d.getTime()) ? fallback : d;
+}
 
 interface TransactionFiltersProps {
   categories: Category[];
   allTransactions: TransactionWithCategory[];
-  initialFrom: Date;
-  initialTo: Date;
-  amountMax: number;
 }
 
-export function TransactionFilters({
-  categories,
-  allTransactions,
-  initialFrom,
-  initialTo,
-  amountMax,
-}: TransactionFiltersProps) {
-  const router = useRouter();
-  const pathname = usePathname();
+export function TransactionFilters({ categories, allTransactions }: TransactionFiltersProps) {
   const searchParams = useSearchParams();
 
-  // Read filter state from URL — useSearchParams updates optimistically on router.replace(),
-  // so the UI responds immediately without waiting for the server RSC round-trip.
-  const sort = searchParams.get("sort") === "asc" ? "asc" : "desc";
-  const selectedCategories = searchParams.get("categories")?.split(",").filter(Boolean) ?? [];
+  const dflt = defaultDateRange();
+  const [dateRange, setDateRange] = useState<DateRange>(() => ({
+    from: parseDate(searchParams.get("from"), dflt.from),
+    to: parseDate(searchParams.get("to"), dflt.to),
+  }));
+  const [sort, setSort] = useState<"asc" | "desc">(() =>
+    searchParams.get("sort") === "asc" ? "asc" : "desc"
+  );
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(() =>
+    searchParams.get("categories")?.split(",").filter(Boolean) ?? []
+  );
+  // null means "full range" (no amount filtering); set by user interaction
+  const [amountRange, setAmountRange] = useState<[number, number] | null>(null);
 
-  const [amountRange, setAmountRange] = useState<[number, number]>([0, amountMax]);
+  const startISO = toISODate(dateRange.from);
+  const endISO = toISODate(dateRange.to);
+  const rangeFiltered = filterByRange(allTransactions, startISO, endISO);
+  const amountMax = rangeFiltered.length ? Math.max(...rangeFiltered.map((t) => t.amount)) : 0;
+  const effectiveAmountRange = amountRange ?? [0, amountMax];
 
-  useEffect(() => {
-    setAmountRange([0, amountMax]);
-  }, [amountMax]);
-
-  function updateParams(updates: Record<string, string | null>) {
-    const params = new URLSearchParams(searchParams.toString());
+  // Sync URL without triggering a Next.js navigation (no RSC round-trip)
+  function updateURL(updates: Record<string, string | null>) {
+    const params = new URLSearchParams(window.location.search);
     for (const [key, val] of Object.entries(updates)) {
-      if (val === null || val === "") {
-        params.delete(key);
-      } else {
-        params.set(key, val);
-      }
+      if (val === null || val === "") params.delete(key);
+      else params.set(key, val);
     }
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    window.history.replaceState(null, "", `${window.location.pathname}?${params.toString()}`);
   }
 
   function handleDateChange(range: DateRange) {
-    updateParams({ from: toISODate(range.from), to: toISODate(range.to) });
+    setDateRange(range);
+    setAmountRange(null); // reset amount filter on date change
+    updateURL({ from: toISODate(range.from), to: toISODate(range.to) });
   }
 
   function handleCategoriesChange(ids: string[]) {
-    updateParams({ categories: ids.join(",") });
+    setSelectedCategories(ids);
+    updateURL({ categories: ids.join(",") });
   }
 
   function toggleSort() {
-    updateParams({ sort: sort === "desc" ? "asc" : "desc" });
+    const newSort = sort === "desc" ? "asc" : "desc";
+    setSort(newSort);
+    updateURL({ sort: newSort });
   }
 
-  const filtered = allTransactions.filter((t) => {
-    const inAmount = t.amount >= amountRange[0] && t.amount <= amountRange[1];
+  const filtered = rangeFiltered.filter((t) => {
+    const inAmount =
+      amountRange === null ||
+      (t.amount >= effectiveAmountRange[0] && t.amount <= effectiveAmountRange[1]);
     const inCategory =
       selectedCategories.length === 0 ||
       (t.category_id !== null && selectedCategories.includes(t.category_id));
@@ -83,10 +101,7 @@ export function TransactionFilters({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-end gap-3">
-        <DateRangePicker
-          value={{ from: initialFrom, to: initialTo }}
-          onChange={handleDateChange}
-        />
+        <DateRangePicker value={dateRange} onChange={handleDateChange} />
         <CategoryMultiSelect
           categories={categories}
           selected={selectedCategories}
@@ -96,7 +111,7 @@ export function TransactionFilters({
           <AmountRangeSlider
             min={0}
             max={amountMax}
-            value={amountRange}
+            value={effectiveAmountRange}
             onChange={setAmountRange}
           />
         )}

--- a/src/components/transactions/TransactionFilters.tsx
+++ b/src/components/transactions/TransactionFilters.tsx
@@ -62,12 +62,21 @@ export function TransactionFilters({
     updateParams({ sort: sort === "desc" ? "asc" : "desc" });
   }
 
-  // Client-side amount filter applied to the already-server-filtered list
-  const filtered = allTransactions.filter(
-    (t) => t.amount >= amountRange[0] && t.amount <= amountRange[1]
-  );
+  const filtered = allTransactions.filter((t) => {
+    const inAmount = t.amount >= amountRange[0] && t.amount <= amountRange[1];
+    const inCategory =
+      initialSelectedCategories.length === 0 ||
+      (t.category_id !== null && initialSelectedCategories.includes(t.category_id));
+    return inAmount && inCategory;
+  });
 
-  const sorted = filtered;
+  const sorted = [...filtered].sort((a, b) => {
+    const dateCmp = a.date.localeCompare(b.date);
+    if (dateCmp !== 0) return sort === "asc" ? dateCmp : -dateCmp;
+    return sort === "asc"
+      ? a.created_at.localeCompare(b.created_at)
+      : b.created_at.localeCompare(a.created_at);
+  });
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/components/transactions/TransactionFilters.tsx
+++ b/src/components/transactions/TransactionFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { ArrowUpDown } from "lucide-react";
 import { Category, TransactionWithCategory } from "@/types/database";
@@ -15,9 +15,6 @@ interface TransactionFiltersProps {
   allTransactions: TransactionWithCategory[];
   initialFrom: Date;
   initialTo: Date;
-  initialSelectedCategories: string[];
-  initialSort: "asc" | "desc";
-  amountMin: number;
   amountMax: number;
 }
 
@@ -26,17 +23,22 @@ export function TransactionFilters({
   allTransactions,
   initialFrom,
   initialTo,
-  initialSelectedCategories,
-  initialSort,
-  amountMin,
   amountMax,
 }: TransactionFiltersProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const [amountRange, setAmountRange] = useState<[number, number]>([amountMin, amountMax]);
-  const sort = initialSort;
+  // Read filter state from URL — useSearchParams updates optimistically on router.replace(),
+  // so the UI responds immediately without waiting for the server RSC round-trip.
+  const sort = searchParams.get("sort") === "asc" ? "asc" : "desc";
+  const selectedCategories = searchParams.get("categories")?.split(",").filter(Boolean) ?? [];
+
+  const [amountRange, setAmountRange] = useState<[number, number]>([0, amountMax]);
+
+  useEffect(() => {
+    setAmountRange([0, amountMax]);
+  }, [amountMax]);
 
   function updateParams(updates: Record<string, string | null>) {
     const params = new URLSearchParams(searchParams.toString());
@@ -65,8 +67,8 @@ export function TransactionFilters({
   const filtered = allTransactions.filter((t) => {
     const inAmount = t.amount >= amountRange[0] && t.amount <= amountRange[1];
     const inCategory =
-      initialSelectedCategories.length === 0 ||
-      (t.category_id !== null && initialSelectedCategories.includes(t.category_id));
+      selectedCategories.length === 0 ||
+      (t.category_id !== null && selectedCategories.includes(t.category_id));
     return inAmount && inCategory;
   });
 
@@ -87,12 +89,12 @@ export function TransactionFilters({
         />
         <CategoryMultiSelect
           categories={categories}
-          selected={initialSelectedCategories}
+          selected={selectedCategories}
           onChange={handleCategoriesChange}
         />
-        {amountMax > amountMin && (
+        {amountMax > 0 && (
           <AmountRangeSlider
-            min={amountMin}
+            min={0}
             max={amountMax}
             value={amountRange}
             onChange={setAmountRange}

--- a/src/lib/client-cache.ts
+++ b/src/lib/client-cache.ts
@@ -1,0 +1,57 @@
+import { Category, TransactionWithCategory } from "@/types/database";
+
+export interface CachedUserData {
+  userId: string;
+  fingerprint: string;
+  cachedAt: number;
+  transactions: TransactionWithCategory[];
+  categories: Category[];
+}
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const cacheKey = (uid: string) => `budget-buddy:cache:${uid}`;
+
+function isValidCache(data: unknown): data is CachedUserData {
+  if (!data || typeof data !== "object") return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.userId === "string" &&
+    typeof d.fingerprint === "string" &&
+    typeof d.cachedAt === "number" &&
+    Array.isArray(d.transactions) &&
+    Array.isArray(d.categories)
+  );
+}
+
+export function loadCache(userId: string): CachedUserData | null {
+  try {
+    const raw = localStorage.getItem(cacheKey(userId));
+    if (!raw) return null;
+    const data: unknown = JSON.parse(raw);
+    if (!isValidCache(data)) return null;
+    if (data.userId !== userId) return null;
+    if (Date.now() - data.cachedAt > TTL_MS) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCache(data: CachedUserData): void {
+  try {
+    localStorage.setItem(cacheKey(data.userId), JSON.stringify(data));
+  } catch {
+    // QuotaExceededError or unavailable localStorage — in-memory state still works
+  }
+}
+
+export function clearAllCaches(): void {
+  try {
+    const keys = Object.keys(localStorage).filter((k) =>
+      k.startsWith("budget-buddy:cache:")
+    );
+    keys.forEach((k) => localStorage.removeItem(k));
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/compute.ts
+++ b/src/lib/compute.ts
@@ -1,0 +1,75 @@
+import { Category, OverviewCategoryItem, OverviewData, OverviewTransaction, TransactionWithCategory } from "@/types/database";
+
+export function filterByRange(
+  transactions: TransactionWithCategory[],
+  from: string,
+  to: string
+): TransactionWithCategory[] {
+  return transactions.filter((t) => t.date >= from && t.date <= to);
+}
+
+export function computeOverviewData(
+  transactions: TransactionWithCategory[],
+  from: string,
+  to: string
+): OverviewData {
+  const inRange = filterByRange(transactions, from, to);
+
+  const overviewTransactions: OverviewTransaction[] = inRange.map((t) => ({
+    date: t.date,
+    amount: t.amount,
+    type: t.type,
+  }));
+
+  const breakdownMap = new Map<string, OverviewCategoryItem>();
+  let totalIncome = 0;
+  let totalExpense = 0;
+
+  for (const t of inRange) {
+    const id = t.category_id ?? "uncategorized";
+    const cat = t.categories;
+    const name = cat?.name ?? "Uncategorized";
+    const color = cat?.color ?? null;
+    const icon = cat?.icon ?? "circle";
+
+    if (t.type === "income") totalIncome += t.amount;
+    else totalExpense += t.amount;
+
+    const existing = breakdownMap.get(id);
+    if (existing) {
+      existing.total += t.amount;
+      existing.count += 1;
+    } else {
+      breakdownMap.set(id, {
+        categoryId: t.category_id,
+        name,
+        color,
+        icon,
+        total: t.amount,
+        count: 1,
+        type: t.type,
+      });
+    }
+  }
+
+  const categoryBreakdown = Array.from(breakdownMap.values()).sort(
+    (a, b) => b.total - a.total
+  );
+
+  return { transactions: overviewTransactions, categoryBreakdown, totalIncome, totalExpense };
+}
+
+export function computeFingerprint(
+  transactions: TransactionWithCategory[],
+  categories: Category[]
+): string {
+  const txMax = transactions.reduce(
+    (max, t) => (t.updated_at > max ? t.updated_at : max),
+    ""
+  );
+  const catMax = categories.reduce(
+    (max, c) => (c.updated_at > max ? c.updated_at : max),
+    ""
+  );
+  return `tx:${transactions.length}:${txMax}|cat:${categories.length}:${catMax}`;
+}

--- a/src/providers/DataProvider.tsx
+++ b/src/providers/DataProvider.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { Category, TransactionWithCategory } from "@/types/database";
+import { loadCache, saveCache } from "@/lib/client-cache";
+import { computeFingerprint } from "@/lib/compute";
+import { getAllData, getFingerprint } from "@/app/actions/data-actions";
+
+export type DataStatus = "loading" | "ready" | "syncing";
+
+export type TransactionPatch =
+  | { op: "add"; transaction: TransactionWithCategory }
+  | { op: "delete"; id: string }
+  | { op: "update"; transaction: TransactionWithCategory };
+
+export interface DataContextValue {
+  transactions: TransactionWithCategory[];
+  categories: Category[];
+  status: DataStatus;
+  applyTransaction: (patch: TransactionPatch) => void;
+  invalidateAndRefetch: () => Promise<void>;
+}
+
+const DataContext = createContext<DataContextValue | null>(null);
+
+export function useData(): DataContextValue {
+  const ctx = useContext(DataContext);
+  if (!ctx) throw new Error("useData must be used inside DataProvider");
+  return ctx;
+}
+
+interface DataProviderProps {
+  userId: string;
+  children: React.ReactNode;
+}
+
+export function DataProvider({ userId, children }: DataProviderProps) {
+  const [transactions, setTransactions] = useState<TransactionWithCategory[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [status, setStatus] = useState<DataStatus>("loading");
+  const fingerprintRef = useRef<string>("");
+
+  function persist(
+    txs: TransactionWithCategory[],
+    cats: Category[],
+    fingerprint: string
+  ) {
+    fingerprintRef.current = fingerprint;
+    saveCache({ userId, fingerprint, cachedAt: Date.now(), transactions: txs, categories: cats });
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      const cached = loadCache(userId);
+
+      if (cached) {
+        setTransactions(cached.transactions);
+        setCategories(cached.categories);
+        fingerprintRef.current = cached.fingerprint;
+        setStatus("ready");
+
+        // Background fingerprint check — only re-download if stale
+        try {
+          const fp = await getFingerprint();
+          if (cancelled || !fp.success) return;
+          if (fp.fingerprint === fingerprintRef.current) return;
+
+          // Stale: re-download silently
+          setStatus("syncing");
+          const fresh = await getAllData();
+          if (cancelled) return;
+          if (fresh.success && fresh.data) {
+            setTransactions(fresh.data.transactions);
+            setCategories(fresh.data.categories);
+            persist(fresh.data.transactions, fresh.data.categories, fresh.data.fingerprint);
+          }
+          setStatus("ready");
+        } catch {
+          // Network error: keep cached data, stay ready
+        }
+      } else {
+        // No cache: full fetch
+        const fresh = await getAllData();
+        if (cancelled) return;
+        if (fresh.success && fresh.data) {
+          setTransactions(fresh.data.transactions);
+          setCategories(fresh.data.categories);
+          persist(fresh.data.transactions, fresh.data.categories, fresh.data.fingerprint);
+        }
+        setStatus("ready");
+      }
+    }
+
+    init();
+    return () => { cancelled = true; };
+  }, [userId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function applyTransaction(patch: TransactionPatch) {
+    setTransactions((prev) => {
+      let next: TransactionWithCategory[];
+      if (patch.op === "add") {
+        next = [patch.transaction, ...prev];
+      } else if (patch.op === "delete") {
+        next = prev.filter((t) => t.id !== patch.id);
+      } else {
+        next = prev.map((t) => (t.id === patch.transaction.id ? patch.transaction : t));
+      }
+      persist(next, categories, computeFingerprint(next, categories));
+      return next;
+    });
+  }
+
+  async function invalidateAndRefetch() {
+    setStatus("syncing");
+    const fresh = await getAllData();
+    if (fresh.success && fresh.data) {
+      setTransactions(fresh.data.transactions);
+      setCategories(fresh.data.categories);
+      persist(fresh.data.transactions, fresh.data.categories, fresh.data.fingerprint);
+    }
+    setStatus("ready");
+  }
+
+  return (
+    <DataContext.Provider
+      value={{ transactions, categories, status, applyTransaction, invalidateAndRefetch }}
+    >
+      {status === "syncing" && (
+        <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs text-zinc-500 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-zinc-400 dark:bg-zinc-500" />
+          Syncing…
+        </div>
+      )}
+      {children}
+    </DataContext.Provider>
+  );
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -8,6 +8,7 @@ export interface Category {
     color: string; // hex color code
     icon: string;  // Lucide icon name (kebab-case)
     created_at: string;
+    updated_at: string;
 }
 
 export interface CategoryInsert {
@@ -27,6 +28,7 @@ export interface Transaction {
     description: string | null;
     date: string; // ISO string YYYY-MM-DD
     created_at: string;
+    updated_at: string;
 }
 
 export interface TransactionInsert {

--- a/supabase/migrations/20260501_add_updated_at.sql
+++ b/supabase/migrations/20260501_add_updated_at.sql
@@ -1,0 +1,39 @@
+-- =====================================================
+-- Budget Buddy - Add updated_at to transactions and categories
+-- =====================================================
+-- Self-contained. Run independently against any environment.
+-- Enables fingerprint-based client-side cache invalidation.
+
+-- 1. Add updated_at column to transactions
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Backfill existing rows with created_at so the column is meaningful
+UPDATE public.transactions SET updated_at = created_at WHERE updated_at = NOW();
+
+-- 2. Add updated_at column to categories
+ALTER TABLE public.categories
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+UPDATE public.categories SET updated_at = created_at WHERE updated_at = NOW();
+
+-- 3. Trigger function (shared)
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4. Attach trigger to transactions
+DROP TRIGGER IF EXISTS trg_transactions_updated_at ON public.transactions;
+CREATE TRIGGER trg_transactions_updated_at
+  BEFORE UPDATE ON public.transactions
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- 5. Attach trigger to categories
+DROP TRIGGER IF EXISTS trg_categories_updated_at ON public.categories;
+CREATE TRIGGER trg_categories_updated_at
+  BEFORE UPDATE ON public.categories
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();


### PR DESCRIPTION
## Summary

- **`DataProvider`** — new \`"use client"\` context that downloads all transactions + categories once via \`getAllData()\`, stores them in \`localStorage\` (user-scoped key, 24h TTL), and serves every range/filter change from memory — zero server calls during date-range navigation
- **Fingerprint check** — on each mount, a cheap \`getFingerprint()\` call (2 DB queries: \`COUNT + MAX(updated_at)\`) runs in the background; if the fingerprint differs from the cached one a silent re-download is triggered so cross-device changes appear automatically
- **Local-first mutations** — \`addTransaction\`, \`deleteTransaction\`, \`updateTransactionCategory\` now return the affected row(s); mutation components call \`applyTransaction(patch)\` to update the local cache immediately, keeping the local fingerprint in sync with the server so local writes never trigger a re-download
- **Import** calls \`invalidateAndRefetch()\` (full re-download) since many rows may be added at once
- **Sign-out** calls \`clearAllCaches()\` to remove all \`budget-buddy:cache:*\` localStorage keys
- **Migration** adds \`updated_at TIMESTAMPTZ\` + \`ON UPDATE\` triggers to \`transactions\` and \`categories\` — already applied ✓

## Architecture notes

\`DataProvider\` only receives \`userId\` as a prop. Because date-range params are not props, React preserves the provider instance across URL-param navigation — so clicking \`<\` / \`>\` to change the period never mounts a fresh provider or hits the server. Content components (\`OverviewClientContent\`, \`TransactionsClientContent\`) derive their view via pure \`filterByRange\` / \`computeOverviewData\` calls in \`src/lib/compute.ts\`.

## Conservative choices

- \`revalidatePath\` calls are kept in all mutation actions — harmless, ensures direct-URL access stays fresh
- No \`useMemo\`/\`useCallback\` per CLAUDE.md — React Compiler handles memoisation
- \`getAllData\` fetches up to 1000 transactions (fingerprint computed inline from fetched rows — no extra round-trip)

## Test plan

- [ ] First load: skeleton shown once, then instant renders
- [ ] Inspect DevTools → Application → localStorage: \`budget-buddy:cache:{userId}\` present with \`transactions\`, \`categories\`, \`fingerprint\`
- [ ] Click \`<\` / \`>\` — content updates instantly, Network tab shows no Supabase data calls
- [ ] Add transaction → appears in list immediately (no reload)
- [ ] Delete transaction → row disappears immediately
- [ ] Recategorize → category updates immediately
- [ ] Import → modal closes after data refreshes, all imported rows visible
- [ ] Sign out → localStorage cache key removed
- [ ] Sign back in → fresh fetch on first load
- [ ] \`npm run lint\` — clean; \`npm run build\` — clean
- [ ] \`npx playwright test\` — all pass

Closes #12