### PR TITLE
AI-powered transaction categorization with review UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "budget-buddy",
       "version": "0.1.0",
       "dependencies": {
-        "@google/generative-ai": "^0.24.1",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
+        "groq-sdk": "^1.2.0",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -904,15 +904,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4787,6 +4778,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/groq-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-1.2.0.tgz",
+      "integrity": "sha512-pMhSYXWcjiqvbOeKdv2zjci1BYjGdp04a40hnmQmJpKJyB6oa+gRndAqE128gwR0NLgYO+Wt1fIF46KNHcplsw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "groq-sdk": "bin/cli"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6367,7 +6367,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "budget-buddy",
       "version": "0.1.0",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
         "lucide-react": "^0.563.0",
@@ -903,6 +904,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -6357,6 +6367,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "test:e2e-video": "playwright test --config=playwright.video.config.ts"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.24.1",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
+    "groq-sdk": "^1.2.0",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e-video": "playwright test --config=playwright.video.config.ts"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
     "lucide-react": "^0.563.0",

--- a/src/app/actions/import-transactions.ts
+++ b/src/app/actions/import-transactions.ts
@@ -141,6 +141,8 @@ export async function importTransactions(formData: FormData): Promise<ImportResu
     revalidatePath('/overview');
 
     const hasUnknown = allTxContext.some(tx => tx.matchedCategoryName === null);
+    console.log('[import] inserted:', importedCount, 'hasUnknown:', hasUnknown, 'allTxContext.length:', allTxContext.length);
+
     if (hasUnknown) {
         const [{ data: categories }, { data: rules }] = await Promise.all([
             supabase.from('categories').select('id, name, category_type, color, icon, created_at, updated_at, user_id').eq('user_id', user.id),
@@ -152,6 +154,8 @@ export async function importTransactions(formData: FormData): Promise<ImportResu
             categories ?? [],
             rules ?? [],
         );
+
+        console.log('[import] aiPropose result:', pendingReview ? `${pendingReview.transactions.length} txs, ${pendingReview.rules.length} rules` : 'null');
 
         if (pendingReview) {
             return { success: true, count: importedCount, duplicateCount, pendingReview };

--- a/src/app/actions/import-transactions.ts
+++ b/src/app/actions/import-transactions.ts
@@ -4,12 +4,16 @@ import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { parseBBVA, ParsedTransaction } from "@/lib/parsers/bbva-parser";
 import { guessCategory } from "@/lib/categorization/engine";
+import { aiPropose, TxContext } from "@/lib/categorization/ai-categorizer";
+import { AiReviewProposal, AiCategoryProposal } from "@/types/database";
+import { createCategory } from "@/app/actions/category-actions";
 
 interface ImportResult {
     success: boolean;
     count?: number;
     duplicateCount?: number;
     error?: string;
+    pendingReview?: AiReviewProposal;
 }
 
 export async function importTransactions(formData: FormData): Promise<ImportResult> {
@@ -52,6 +56,8 @@ export async function importTransactions(formData: FormData): Promise<ImportResu
 
     let importedCount = 0;
     let duplicateCount = 0;
+    const allTxContext: TxContext[] = [];
+    let txIndex = 0;
 
     for (const [, trs] of groupedFileTransactions.entries()) {
         const tr = trs[0];
@@ -80,34 +86,157 @@ export async function importTransactions(formData: FormData): Promise<ImportResu
         const toAddNow = Math.max(0, inThisFile - existingInDb);
         duplicateCount += (inThisFile - toAddNow);
 
-        if (toAddNow <= 0) continue;
+        if (toAddNow <= 0) {
+            txIndex += inThisFile;
+            continue;
+        }
 
-        // NEW: Resolve Category using Inference Engine
-        const { categoryId: guessedId } = await guessCategory(supabase, user.id, description, type);
-
-        // If no category found, we allow it to be NULL (Uncategorized)
+        const { categoryId: guessedId, source } = await guessCategory(supabase, user.id, description, type);
         const finalCategoryId = guessedId || null;
 
-        // Insert missing instances
-        for (let i = 0; i < toAddNow; i++) {
-            const { error: insertError } = await supabase.from('transactions').insert({
-                user_id: user.id,
-                amount: absAmount,
-                type: type,
-                category_id: finalCategoryId,
-                description: description,
-                date: tr.date,
-            });
+        // Fetch the matched category name for AI context
+        let matchedCategoryName: string | null = null;
+        if (finalCategoryId && source !== 'UNKNOWN') {
+            const { data: cat } = await supabase
+                .from('categories')
+                .select('name')
+                .eq('id', finalCategoryId)
+                .single();
+            matchedCategoryName = cat?.name ?? null;
+        }
 
-            if (!insertError) {
+        for (let i = 0; i < toAddNow; i++) {
+            const { data: inserted, error: insertError } = await supabase
+                .from('transactions')
+                .insert({
+                    user_id: user.id,
+                    amount: absAmount,
+                    type: type,
+                    category_id: finalCategoryId,
+                    description: description,
+                    date: tr.date,
+                })
+                .select('id')
+                .single();
+
+            if (!insertError && inserted) {
                 importedCount++;
-            } else {
+                allTxContext.push({
+                    index: txIndex,
+                    transactionId: inserted.id,
+                    description,
+                    amount: absAmount,
+                    type,
+                    date: tr.date,
+                    matchedCategoryName,
+                });
+            } else if (insertError) {
                 console.error("Failed to insert transaction:", insertError.message);
             }
+            txIndex++;
         }
     }
 
     revalidatePath('/transactions');
     revalidatePath('/overview');
+
+    const hasUnknown = allTxContext.some(tx => tx.matchedCategoryName === null);
+    if (hasUnknown) {
+        const [{ data: categories }, { data: rules }] = await Promise.all([
+            supabase.from('categories').select('id, name, category_type, color, icon, created_at, updated_at, user_id').eq('user_id', user.id),
+            supabase.from('merchant_rules').select('match_pattern, match_type, category_id').eq('user_id', user.id),
+        ]);
+
+        const pendingReview = await aiPropose(
+            allTxContext,
+            categories ?? [],
+            rules ?? [],
+        );
+
+        if (pendingReview) {
+            return { success: true, count: importedCount, duplicateCount, pendingReview };
+        }
+    }
+
     return { success: true, count: importedCount, duplicateCount };
+}
+
+export async function approveReview(
+    transactions: Array<{ transactionId: string; categoryId: string | null; newCategory: AiCategoryProposal | null }>,
+    rules: Array<{ match_pattern: string; match_type: 'EXACT' | 'CONTAINS'; categoryId: string | null; newCategory: AiCategoryProposal | null }>,
+): Promise<{ success: boolean; error?: string }> {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) return { success: false, error: 'User not authenticated' };
+
+    // Collect unique new categories to create (dedup by name + category_type)
+    const newCategoriesNeeded = new Map<string, AiCategoryProposal>();
+    for (const tx of transactions) {
+        if (tx.newCategory) {
+            const key = `${tx.newCategory.name}:${tx.newCategory.category_type}`;
+            if (!newCategoriesNeeded.has(key)) newCategoriesNeeded.set(key, tx.newCategory);
+        }
+    }
+    for (const rule of rules) {
+        if (rule.newCategory) {
+            const key = `${rule.newCategory.name}:${rule.newCategory.category_type}`;
+            if (!newCategoriesNeeded.has(key)) newCategoriesNeeded.set(key, rule.newCategory);
+        }
+    }
+
+    // Create new categories and build name:type → id map
+    const resolvedIds = new Map<string, string>();
+    for (const [key, proposal] of newCategoriesNeeded.entries()) {
+        const result = await createCategory(proposal);
+        if (result.success && result.data) {
+            resolvedIds.set(key, result.data.id);
+        } else if (!result.success && result.error?.includes('already exists')) {
+            // Category already exists — look it up
+            const { data: existing } = await supabase
+                .from('categories')
+                .select('id')
+                .eq('user_id', user.id)
+                .eq('name', proposal.name)
+                .eq('category_type', proposal.category_type)
+                .single();
+            if (existing) resolvedIds.set(key, existing.id);
+        }
+    }
+
+    const resolveCategoryId = (categoryId: string | null, newCategory: AiCategoryProposal | null): string | null => {
+        if (categoryId) return categoryId;
+        if (newCategory) {
+            const key = `${newCategory.name}:${newCategory.category_type}`;
+            return resolvedIds.get(key) ?? null;
+        }
+        return null;
+    };
+
+    // Update transaction categories
+    for (const tx of transactions) {
+        const resolvedId = resolveCategoryId(tx.categoryId, tx.newCategory);
+        if (!resolvedId) continue;
+        await supabase
+            .from('transactions')
+            .update({ category_id: resolvedId })
+            .eq('id', tx.transactionId)
+            .eq('user_id', user.id);
+    }
+
+    // Upsert merchant rules
+    for (const rule of rules) {
+        const resolvedId = resolveCategoryId(rule.categoryId, rule.newCategory);
+        if (!resolvedId) continue;
+        await supabase
+            .from('merchant_rules')
+            .upsert(
+                { user_id: user.id, match_pattern: rule.match_pattern, match_type: rule.match_type, category_id: resolvedId },
+                { onConflict: 'user_id, match_pattern' },
+            );
+    }
+
+    revalidatePath('/transactions');
+    revalidatePath('/overview');
+    return { success: true };
 }

--- a/src/components/ImportTransactionsForm.tsx
+++ b/src/components/ImportTransactionsForm.tsx
@@ -1,23 +1,53 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { importTransactions } from "@/app/actions/import-transactions";
-import { Upload, File as FileIcon, X, Loader2, CheckCircle, AlertCircle } from "lucide-react";
+import { importTransactions, approveReview } from "@/app/actions/import-transactions";
+import { AiReviewProposal, AiCategoryProposal, AiTransactionProposal, AiRuleProposal } from "@/types/database";
+import { useData } from "@/providers/DataProvider";
+import { Upload, File as FileIcon, X, Loader2, CheckCircle, AlertCircle, Sparkles } from "lucide-react";
 
 interface ImportTransactionsFormProps {
     onSuccess?: () => void;
 }
 
+interface TxEdit {
+    categoryId: string | null;
+    newCategory: AiCategoryProposal | null;
+}
+
+function collectNewCategories(proposals: AiReviewProposal): AiCategoryProposal[] {
+    const seen = new Set<string>();
+    const result: AiCategoryProposal[] = [];
+    const all = [
+        ...proposals.transactions.map(t => t.newCategory),
+        ...proposals.rules.map(r => r.newCategory),
+    ];
+    for (const nc of all) {
+        if (!nc) continue;
+        const key = `${nc.name}:${nc.category_type}`;
+        if (!seen.has(key)) {
+            seen.add(key);
+            result.push(nc);
+        }
+    }
+    return result;
+}
+
 export function ImportTransactionsForm({ onSuccess }: ImportTransactionsFormProps) {
+    const { categories, invalidateAndRefetch } = useData();
     const [file, setFile] = useState<File | null>(null);
     const [isDragging, setIsDragging] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [isApproving, setIsApproving] = useState(false);
     const [result, setResult] = useState<{
         success: boolean;
         count?: number;
         duplicateCount?: number;
         error?: string;
+        pendingReview?: AiReviewProposal;
     } | null>(null);
+    const [txEdits, setTxEdits] = useState<Map<string, TxEdit>>(new Map());
+    const [dismissedRules, setDismissedRules] = useState<Set<number>>(new Set());
 
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -53,6 +83,8 @@ export function ImportTransactionsForm({ onSuccess }: ImportTransactionsFormProp
 
         setIsLoading(true);
         setResult(null);
+        setTxEdits(new Map());
+        setDismissedRules(new Set());
 
         const formData = new FormData();
         formData.append("file", file);
@@ -61,10 +93,8 @@ export function ImportTransactionsForm({ onSuccess }: ImportTransactionsFormProp
             const res = await importTransactions(formData);
             setResult(res);
 
-            if (res.success) {
-                if (onSuccess) {
-                    setTimeout(() => onSuccess(), 2000);
-                }
+            if (res.success && !res.pendingReview && onSuccess) {
+                setTimeout(() => onSuccess(), 2000);
             }
         } catch {
             setResult({ success: false, error: "An unexpected error occurred." });
@@ -73,33 +103,201 @@ export function ImportTransactionsForm({ onSuccess }: ImportTransactionsFormProp
         }
     }
 
+    async function handleApproveReview() {
+        if (!result?.pendingReview) return;
+        setIsApproving(true);
+
+        const txsToApprove = result.pendingReview.transactions.map((tx: AiTransactionProposal) => {
+            const edit = txEdits.get(tx.transactionId);
+            return {
+                transactionId: tx.transactionId,
+                categoryId: edit ? edit.categoryId : tx.categoryId,
+                newCategory: edit ? edit.newCategory : tx.newCategory,
+            };
+        });
+
+        const rulesToApprove = result.pendingReview.rules
+            .filter((_: AiRuleProposal, i: number) => !dismissedRules.has(i));
+
+        await approveReview(txsToApprove, rulesToApprove);
+        await invalidateAndRefetch();
+        setIsApproving(false);
+        if (onSuccess) onSuccess();
+    }
+
+    function handleSkipAndClose() {
+        if (onSuccess) onSuccess();
+    }
+
+    function handleTxCategoryChange(tx: AiTransactionProposal, value: string) {
+        const newEdits = new Map(txEdits);
+        if (value.startsWith('new:')) {
+            const name = value.slice(4);
+            const allNew = result?.pendingReview ? collectNewCategories(result.pendingReview) : [];
+            const nc = allNew.find(c => c.name === name) ?? null;
+            newEdits.set(tx.transactionId, { categoryId: null, newCategory: nc });
+        } else {
+            newEdits.set(tx.transactionId, { categoryId: value || null, newCategory: null });
+        }
+        setTxEdits(newEdits);
+    }
+
+    function getSelectValue(tx: AiTransactionProposal): string {
+        const edit = txEdits.get(tx.transactionId);
+        const catId = edit ? edit.categoryId : tx.categoryId;
+        const newCat = edit ? edit.newCategory : tx.newCategory;
+        if (catId) return catId;
+        if (newCat) return `new:${newCat.name}`;
+        return '';
+    }
+
     if (result?.success) {
+        const review = result.pendingReview;
+        const aiNewCategories = review ? collectNewCategories(review) : [];
+
         return (
-            <div className="flex flex-col items-center justify-center p-6 text-center space-y-4 animate-in fade-in zoom-in-95 duration-200">
-                <div className="flex items-center justify-center h-12 w-12 rounded-full bg-green-100 dark:bg-green-900/30">
-                    <CheckCircle className="h-6 w-6 text-green-600 dark:text-green-500" />
+            <div className="flex flex-col space-y-4 animate-in fade-in zoom-in-95 duration-200">
+                {/* Success header */}
+                <div className="flex flex-col items-center justify-center p-4 text-center space-y-3">
+                    <div className="flex items-center justify-center h-12 w-12 rounded-full bg-green-100 dark:bg-green-900/30">
+                        <CheckCircle className="h-6 w-6 text-green-600 dark:text-green-500" />
+                    </div>
+                    <h3 className="text-lg font-medium text-zinc-900 dark:text-zinc-50">
+                        Import Successful!
+                    </h3>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                        Successfully imported <span className="font-semibold text-zinc-900 dark:text-zinc-50">{result.count}</span> transactions.
+                        {result.duplicateCount && result.duplicateCount > 0 ? (
+                            <span className="block mt-1">
+                                Skipped {result.duplicateCount} duplicate transactions.
+                            </span>
+                        ) : null}
+                    </p>
                 </div>
-                <h3 className="text-lg font-medium text-zinc-900 dark:text-zinc-50">
-                    Import Successful!
-                </h3>
-                <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                    Successfully imported <span className="font-semibold text-zinc-900 dark:text-zinc-50">{result.count}</span> transactions.
-                    {result.duplicateCount && result.duplicateCount > 0 ? (
-                        <span className="block mt-1">
-                            Skipped {result.duplicateCount} duplicate transactions.
-                        </span>
-                    ) : null}
-                </p>
-                <button
-                    onClick={() => {
-                        setResult(null);
-                        setFile(null);
-                        if (onSuccess) onSuccess();
-                    }}
-                    className="mt-4 w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-                >
-                    Close
-                </button>
+
+                {/* Review panel */}
+                {review && (
+                    <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden">
+                        <div className="flex items-center gap-2 px-4 py-2.5 bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-200 dark:border-zinc-700">
+                            <Sparkles className="h-4 w-4 text-violet-500" />
+                            <span className="text-sm font-medium text-zinc-800 dark:text-zinc-200">AI Categorization Review</span>
+                        </div>
+
+                        {/* Uncategorized transactions */}
+                        {review.transactions.length > 0 && (
+                            <div className="p-3 space-y-1">
+                                <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wide mb-2">
+                                    Uncategorized transactions ({review.transactions.length})
+                                </p>
+                                {review.transactions.map((tx: AiTransactionProposal) => {
+                                    const expenseCategories = categories.filter(c => c.category_type === tx.type);
+                                    return (
+                                        <div key={tx.transactionId} className="flex items-center gap-2 py-1.5">
+                                            <span className="flex-1 text-xs text-zinc-700 dark:text-zinc-300 truncate min-w-0" title={tx.description}>
+                                                {tx.description}
+                                            </span>
+                                            <span className="text-xs text-zinc-500 dark:text-zinc-400 shrink-0">
+                                                €{tx.amount.toFixed(2)}
+                                            </span>
+                                            <select
+                                                value={getSelectValue(tx)}
+                                                onChange={e => handleTxCategoryChange(tx, e.target.value)}
+                                                className="text-xs border border-zinc-200 dark:border-zinc-700 rounded-md px-2 py-1 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 shrink-0 max-w-[140px]"
+                                            >
+                                                <option value="">Uncategorized</option>
+                                                <optgroup label="Categories">
+                                                    {expenseCategories.map(c => (
+                                                        <option key={c.id} value={c.id}>{c.name}</option>
+                                                    ))}
+                                                </optgroup>
+                                                {aiNewCategories.filter(nc => nc.category_type === tx.type).length > 0 && (
+                                                    <optgroup label="AI-suggested (new)">
+                                                        {aiNewCategories
+                                                            .filter(nc => nc.category_type === tx.type)
+                                                            .map(nc => (
+                                                                <option key={nc.name} value={`new:${nc.name}`}>{nc.name}</option>
+                                                            ))}
+                                                    </optgroup>
+                                                )}
+                                            </select>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        {/* New rules */}
+                        {review.rules.length > 0 && (
+                            <div className={`p-3 space-y-1 ${review.transactions.length > 0 ? 'border-t border-zinc-200 dark:border-zinc-700' : ''}`}>
+                                <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wide mb-2">
+                                    New rules to add ({review.rules.filter((_: AiRuleProposal, i: number) => !dismissedRules.has(i)).length}/{review.rules.length})
+                                </p>
+                                {review.rules.map((rule: AiRuleProposal, i: number) => {
+                                    const catName = rule.categoryId
+                                        ? (categories.find(c => c.id === rule.categoryId)?.name ?? '?')
+                                        : (rule.newCategory?.name ?? '?');
+                                    const isDismissed = dismissedRules.has(i);
+                                    return (
+                                        <div key={i} className={`flex items-center gap-2 py-1 ${isDismissed ? 'opacity-40' : ''}`}>
+                                            <code className="flex-1 text-xs bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-600 dark:text-zinc-400 truncate min-w-0">
+                                                {rule.match_type === 'CONTAINS' ? 'contains' : '='} &quot;{rule.match_pattern}&quot;
+                                            </code>
+                                            <span className="text-xs text-zinc-400 shrink-0">→</span>
+                                            <span className="text-xs text-zinc-600 dark:text-zinc-300 shrink-0">
+                                                {catName}{rule.newCategory ? ' (new)' : ''}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    const next = new Set(dismissedRules);
+                                                    if (isDismissed) next.delete(i); else next.add(i);
+                                                    setDismissedRules(next);
+                                                }}
+                                                className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 shrink-0 underline"
+                                            >
+                                                {isDismissed ? 'restore' : 'dismiss'}
+                                            </button>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        {/* Actions */}
+                        <div className="flex gap-2 px-3 pb-3 pt-1">
+                            <button
+                                type="button"
+                                onClick={handleApproveReview}
+                                disabled={isApproving}
+                                className="flex-1 inline-flex items-center justify-center rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors"
+                            >
+                                {isApproving ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Approve & Apply'}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleSkipAndClose}
+                                disabled={isApproving}
+                                className="px-3 py-2 text-sm font-medium text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors"
+                            >
+                                Skip & Close
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {/* Close button when no review */}
+                {!review && (
+                    <button
+                        onClick={() => {
+                            setResult(null);
+                            setFile(null);
+                            if (onSuccess) onSuccess();
+                        }}
+                        className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    >
+                        Close
+                    </button>
+                )}
             </div>
         );
     }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -47,10 +47,10 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
         >
             <div
                 ref={modalRef}
-                className="relative w-full max-w-lg rounded-xl border border-zinc-200 bg-white shadow-2xl animate-in zoom-in-95 duration-200 dark:border-zinc-800 dark:bg-zinc-950"
+                className="relative w-full max-w-lg max-h-[calc(100vh-2rem)] flex flex-col rounded-xl border border-zinc-200 bg-white shadow-2xl animate-in zoom-in-95 duration-200 dark:border-zinc-800 dark:bg-zinc-950"
             >
                 {/* Header */}
-                <div className="flex items-center justify-between border-b border-zinc-100 px-6 py-4 dark:border-zinc-800">
+                <div className="flex shrink-0 items-center justify-between border-b border-zinc-100 px-6 py-4 dark:border-zinc-800">
                     <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
                         {title}
                     </h3>
@@ -64,7 +64,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
                 </div>
 
                 {/* Content */}
-                <div className="p-6">
+                <div className="flex-1 overflow-y-auto p-6">
                     {children}
                 </div>
             </div>

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,0 +1,20 @@
+import Groq from 'groq-sdk';
+
+export type TextProvider = (prompt: string) => Promise<string>;
+
+function groqProvider(apiKey: string): TextProvider {
+    const client = new Groq({ apiKey });
+    return async (prompt: string) => {
+        const response = await client.chat.completions.create({
+            model: 'llama-3.3-70b-versatile',
+            messages: [{ role: 'user', content: prompt }],
+            response_format: { type: 'json_object' },
+        });
+        return response.choices[0].message.content ?? '';
+    };
+}
+
+export function getAiProvider(): TextProvider | null {
+    if (process.env.GROQ_API_KEY) return groqProvider(process.env.GROQ_API_KEY);
+    return null;
+}

--- a/src/lib/categorization/ai-categorizer.ts
+++ b/src/lib/categorization/ai-categorizer.ts
@@ -1,0 +1,229 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { Category, AiReviewProposal, AiTransactionProposal, AiRuleProposal, AiCategoryProposal, TransactionType } from '@/types/database';
+import { CATEGORY_COLORS, CATEGORY_ICONS } from '@/lib/categories/constants';
+
+export interface TxContext {
+    index: number;
+    transactionId: string;
+    description: string;
+    amount: number;
+    type: TransactionType;
+    date: string;
+    matchedCategoryName: string | null;
+}
+
+interface DbRule {
+    match_pattern: string;
+    match_type: string;
+    category_id: string;
+}
+
+interface GeminiCategorization {
+    transactionIndex: number;
+    existingCategoryId: string | null;
+    newCategoryName: string | null;
+    proposedRule: { match_pattern: string; match_type: 'EXACT' | 'CONTAINS' } | null;
+}
+
+interface GeminiStandaloneRule {
+    match_pattern: string;
+    match_type: 'EXACT' | 'CONTAINS';
+    existingCategoryId: string | null;
+    newCategoryName: string | null;
+}
+
+interface GeminiNewCategory {
+    name: string;
+    icon: string;
+    color: string;
+    category_type: TransactionType;
+}
+
+interface GeminiResponse {
+    categorizations: GeminiCategorization[];
+    standaloneRules: GeminiStandaloneRule[];
+    newCategories: GeminiNewCategory[];
+}
+
+export async function aiPropose(
+    allTransactions: TxContext[],
+    categories: Category[],
+    rules: DbRule[],
+): Promise<AiReviewProposal | null> {
+    if (!process.env.GEMINI_API_KEY) return null;
+
+    const unknownTxs = allTransactions.filter(tx => tx.matchedCategoryName === null);
+    if (unknownTxs.length === 0) return null;
+
+    try {
+        const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+        const model = genAI.getGenerativeModel({
+            model: 'gemini-2.0-flash',
+            generationConfig: { responseMimeType: 'application/json' },
+        });
+
+        const txList = allTransactions.map(tx =>
+            `[${tx.index}] ${tx.date} | ${tx.type} | €${tx.amount.toFixed(2)} | "${tx.description}" | category: ${tx.matchedCategoryName ?? 'UNMATCHED'}`
+        ).join('\n');
+
+        const catList = categories.map(c =>
+            `  id=${c.id} name="${c.name}" type=${c.category_type}`
+        ).join('\n');
+
+        const ruleList = rules.length > 0
+            ? rules.map(r => {
+                const cat = categories.find(c => c.id === r.category_id);
+                return `  ${r.match_type} "${r.match_pattern}" → ${cat?.name ?? r.category_id}`;
+            }).join('\n')
+            : '  (none)';
+
+        const prompt = `You are a personal finance assistant. Categorize uncategorized bank transactions.
+
+## All transactions in this import batch
+${txList}
+
+## Existing categories
+${catList}
+
+## Existing merchant rules
+${ruleList}
+
+## Available icons (use exact values)
+${CATEGORY_ICONS.join(', ')}
+
+## Available colors (use exact hex values)
+${CATEGORY_COLORS.join(', ')}
+
+## Task
+1. For each UNMATCHED transaction, assign a category from existing ones or propose a new one.
+2. If the assignment can be expressed as a simple keyword rule (e.g. the merchant always maps to that category), add a proposedRule. Skip the rule for context-dependent cases (e.g. a supermarket purchase during an apparent travel day based on surrounding transactions).
+3. Use the full batch context: if multiple transactions on the same date suggest a travel/trip scenario, group purchases accordingly.
+4. Propose new categories only when no existing one fits. Use valid icon and color values from the lists above.
+5. Avoid duplicating existing rules — check the rule list before proposing new ones.
+
+## Response JSON schema
+{
+  "categorizations": [
+    {
+      "transactionIndex": <number>,
+      "existingCategoryId": "<uuid or null>",
+      "newCategoryName": "<string or null>",
+      "proposedRule": { "match_pattern": "<lowercase keyword>", "match_type": "EXACT | CONTAINS" } | null
+    }
+  ],
+  "standaloneRules": [
+    {
+      "match_pattern": "<lowercase keyword>",
+      "match_type": "EXACT | CONTAINS",
+      "existingCategoryId": "<uuid or null>",
+      "newCategoryName": "<string or null>"
+    }
+  ],
+  "newCategories": [
+    {
+      "name": "<string>",
+      "icon": "<valid icon name>",
+      "color": "<valid hex color>",
+      "category_type": "income | expense"
+    }
+  ]
+}
+
+Only include UNMATCHED transactions in categorizations. Return valid JSON only.`;
+
+        const result = await model.generateContent(prompt);
+        const text = result.response.text();
+        const raw = JSON.parse(text) as GeminiResponse;
+
+        // Build a lookup from newCategoryName → GeminiNewCategory
+        const newCatMap = new Map<string, GeminiNewCategory>(
+            (raw.newCategories ?? []).map(nc => [nc.name, nc])
+        );
+
+        const resolveCategory = (existingId: string | null, newName: string | null): Pick<AiTransactionProposal, 'categoryId' | 'newCategory'> => {
+            if (existingId && categories.find(c => c.id === existingId)) {
+                return { categoryId: existingId, newCategory: null };
+            }
+            if (newName && newCatMap.has(newName)) {
+                const nc = newCatMap.get(newName)!;
+                return {
+                    categoryId: null,
+                    newCategory: {
+                        name: nc.name,
+                        icon: nc.icon,
+                        color: nc.color,
+                        category_type: nc.category_type,
+                    } satisfies AiCategoryProposal,
+                };
+            }
+            // Fallback: if a newName was given but not defined, still expose it with defaults
+            if (newName) {
+                return {
+                    categoryId: null,
+                    newCategory: {
+                        name: newName,
+                        icon: 'wallet',
+                        color: '#3b82f6',
+                        category_type: 'expense',
+                    } satisfies AiCategoryProposal,
+                };
+            }
+            return { categoryId: null, newCategory: null };
+        };
+
+        const transactions: AiTransactionProposal[] = [];
+        for (const c of (raw.categorizations ?? [])) {
+            const tx = allTransactions.find(t => t.index === c.transactionIndex);
+            if (!tx) continue;
+            const { categoryId, newCategory } = resolveCategory(c.existingCategoryId, c.newCategoryName);
+            transactions.push({
+                transactionId: tx.transactionId,
+                description: tx.description,
+                amount: tx.amount,
+                type: tx.type,
+                categoryId,
+                newCategory,
+            });
+        }
+
+        const rules_out: AiRuleProposal[] = [];
+
+        // Rules embedded in categorizations
+        for (const c of (raw.categorizations ?? [])) {
+            if (!c.proposedRule) continue;
+            const { categoryId, newCategory } = resolveCategory(c.existingCategoryId, c.newCategoryName);
+            rules_out.push({
+                match_pattern: c.proposedRule.match_pattern,
+                match_type: c.proposedRule.match_type,
+                categoryId,
+                newCategory,
+            });
+        }
+
+        // Standalone rules
+        for (const r of (raw.standaloneRules ?? [])) {
+            const { categoryId, newCategory } = resolveCategory(r.existingCategoryId, r.newCategoryName);
+            rules_out.push({
+                match_pattern: r.match_pattern,
+                match_type: r.match_type,
+                categoryId,
+                newCategory,
+            });
+        }
+
+        // Deduplicate rules by match_pattern
+        const seenPatterns = new Set<string>();
+        const dedupedRules = rules_out.filter(r => {
+            if (seenPatterns.has(r.match_pattern)) return false;
+            seenPatterns.add(r.match_pattern);
+            return true;
+        });
+
+        if (transactions.length === 0 && dedupedRules.length === 0) return null;
+
+        return { transactions, rules: dedupedRules };
+    } catch (e) {
+        console.error('[ai-categorizer] error:', e);
+        return null;
+    }
+}

--- a/src/lib/categorization/ai-categorizer.ts
+++ b/src/lib/categorization/ai-categorizer.ts
@@ -1,4 +1,4 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { getAiProvider } from '@/lib/ai/provider';
 import { Category, AiReviewProposal, AiTransactionProposal, AiRuleProposal, AiCategoryProposal, TransactionType } from '@/types/database';
 import { CATEGORY_COLORS, CATEGORY_ICONS } from '@/lib/categories/constants';
 
@@ -18,31 +18,31 @@ interface DbRule {
     category_id: string;
 }
 
-interface GeminiCategorization {
+interface AiCategorization {
     transactionIndex: number;
     existingCategoryId: string | null;
     newCategoryName: string | null;
     proposedRule: { match_pattern: string; match_type: 'EXACT' | 'CONTAINS' } | null;
 }
 
-interface GeminiStandaloneRule {
+interface AiStandaloneRule {
     match_pattern: string;
     match_type: 'EXACT' | 'CONTAINS';
     existingCategoryId: string | null;
     newCategoryName: string | null;
 }
 
-interface GeminiNewCategory {
+interface AiNewCategory {
     name: string;
     icon: string;
     color: string;
     category_type: TransactionType;
 }
 
-interface GeminiResponse {
-    categorizations: GeminiCategorization[];
-    standaloneRules: GeminiStandaloneRule[];
-    newCategories: GeminiNewCategory[];
+interface AiResponse {
+    categorizations: AiCategorization[];
+    standaloneRules: AiStandaloneRule[];
+    newCategories: AiNewCategory[];
 }
 
 export async function aiPropose(
@@ -50,18 +50,17 @@ export async function aiPropose(
     categories: Category[],
     rules: DbRule[],
 ): Promise<AiReviewProposal | null> {
-    if (!process.env.GEMINI_API_KEY) return null;
+    const provider = getAiProvider();
+    if (!provider) {
+        console.log('[ai-categorizer] no AI provider configured, skipping');
+        return null;
+    }
 
     const unknownTxs = allTransactions.filter(tx => tx.matchedCategoryName === null);
+    console.log('[ai-categorizer] unknownTxs:', unknownTxs.length, '/', allTransactions.length);
     if (unknownTxs.length === 0) return null;
 
     try {
-        const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-        const model = genAI.getGenerativeModel({
-            model: 'gemini-2.0-flash',
-            generationConfig: { responseMimeType: 'application/json' },
-        });
-
         const txList = allTransactions.map(tx =>
             `[${tx.index}] ${tx.date} | ${tx.type} | €${tx.amount.toFixed(2)} | "${tx.description}" | category: ${tx.matchedCategoryName ?? 'UNMATCHED'}`
         ).join('\n');
@@ -131,12 +130,12 @@ ${CATEGORY_COLORS.join(', ')}
 
 Only include UNMATCHED transactions in categorizations. Return valid JSON only.`;
 
-        const result = await model.generateContent(prompt);
-        const text = result.response.text();
-        const raw = JSON.parse(text) as GeminiResponse;
+        console.log('[ai-categorizer] calling provider...');
+        const text = await provider(prompt);
+        console.log('[ai-categorizer] response length:', text.length);
+        const raw = JSON.parse(text) as AiResponse;
 
-        // Build a lookup from newCategoryName → GeminiNewCategory
-        const newCatMap = new Map<string, GeminiNewCategory>(
+        const newCatMap = new Map<string, AiNewCategory>(
             (raw.newCategories ?? []).map(nc => [nc.name, nc])
         );
 
@@ -223,7 +222,8 @@ Only include UNMATCHED transactions in categorizations. Return valid JSON only.`
 
         return { transactions, rules: dedupedRules };
     } catch (e) {
-        console.error('[ai-categorizer] error:', e);
+        console.error('[ai-categorizer] error:', e instanceof Error ? e.message : e);
+        if (e instanceof Error && e.stack) console.error(e.stack);
         return null;
     }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -75,3 +75,31 @@ export interface OverviewData {
   totalExpense: number;
 }
 
+export interface AiCategoryProposal {
+  name: string;
+  icon: string;
+  color: string;
+  category_type: TransactionType;
+}
+
+export interface AiTransactionProposal {
+  transactionId: string;
+  description: string;
+  amount: number;
+  type: TransactionType;
+  categoryId: string | null;
+  newCategory: AiCategoryProposal | null;
+}
+
+export interface AiRuleProposal {
+  match_pattern: string;
+  match_type: 'EXACT' | 'CONTAINS';
+  categoryId: string | null;
+  newCategory: AiCategoryProposal | null;
+}
+
+export interface AiReviewProposal {
+  transactions: AiTransactionProposal[];
+  rules: AiRuleProposal[];
+}
+

--- a/temp/plan.md
+++ b/temp/plan.md
@@ -1,0 +1,124 @@
+# AI Categorization — Handoff Plan
+
+## What was built
+
+Added a two-layer transaction categorization system to Budget Buddy:
+
+1. **Rule layer** (existing): `merchant_rules` table — description-based EXACT/CONTAINS patterns, run during import via `guessCategory()`.
+2. **AI layer** (new): Gemini 2.0 Flash — runs after insert when any transactions are UNKNOWN (no rule match). Returns proposed categorizations + new merchant rules, which the user reviews and approves before anything is committed.
+
+The AI receives the **full import batch** (including already-categorized transactions) for context-aware grouping — e.g. detecting a travel day from surrounding transactions and overriding a "Groceries" match with "Travel".
+
+---
+
+## Current state
+
+All changes are committed on branch **`feat/ai-categorization`**. No DB migrations required — the existing `merchant_rules` table is sufficient.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/types/database.ts` | Added `AiCategoryProposal`, `AiTransactionProposal`, `AiRuleProposal`, `AiReviewProposal` |
+| `src/lib/categorization/ai-categorizer.ts` | **New** — Gemini 2.0 Flash integration |
+| `src/app/actions/import-transactions.ts` | ID capture on insert, AI call, new `approveReview` server action |
+| `src/components/ImportTransactionsForm.tsx` | Review panel UI shown after import when AI proposals exist |
+| `package.json` / `package-lock.json` | Added `@google/generative-ai` dependency |
+
+---
+
+## Setup required
+
+Add to `.env.local` (and Vercel env vars for production):
+
+```
+GEMINI_API_KEY=your_gemini_api_key_here
+```
+
+Get a key at https://aistudio.google.com/app/apikey (free tier is sufficient).
+
+Without this key the feature is silently disabled — imports work exactly as before.
+
+---
+
+## Architecture notes
+
+### Import flow (updated)
+
+```
+importTransactions()
+  ├── parse + deduplicate (unchanged)
+  ├── for each group:
+  │     ├── guessCategory() → rule match or UNKNOWN
+  │     └── insert with category_id (or null) — captures inserted id
+  ├── if any UNKNOWN transactions AND GEMINI_API_KEY set:
+  │     ├── fetch user categories + merchant_rules
+  │     └── aiPropose(allTxContext, categories, rules) → AiReviewProposal | null
+  └── return { success, count, duplicateCount, pendingReview? }
+```
+
+### AI prompt strategy (`src/lib/categorization/ai-categorizer.ts`)
+
+- Sends all transactions in the batch (with their rule-matched category or "UNMATCHED")
+- Sends existing categories and existing rules (so AI understands the user's taxonomy)
+- Sends valid icon/color lists from `src/lib/categories/constants.ts`
+- Asks AI to: (1) assign a category to each UNMATCHED transaction, (2) propose a merchant rule where applicable (not for context-dependent cases), (3) suggest new categories with valid icon/color if needed
+- Response parsed from JSON (`responseMimeType: 'application/json'`)
+- Returns `null` silently on any error — never breaks the import
+
+### approveReview server action (`src/app/actions/import-transactions.ts`)
+
+- Creates any new AI-proposed categories via `createCategory()`
+- Handles "category already exists" gracefully (looks it up instead)
+- Updates `transactions.category_id` directly (bypasses `updateTransactionCategory` to avoid double-rule creation)
+- Upserts approved rules into `merchant_rules` with `onConflict: 'user_id, match_pattern'`
+
+### Review UI (`src/components/ImportTransactionsForm.tsx`)
+
+- On import success with `pendingReview`: shows review panel instead of auto-closing
+- Each UNKNOWN transaction: `<select>` with existing categories + AI-suggested new ones (grouped by `<optgroup>`)
+- Each proposed rule: dismissable individually (dismissed rules are excluded from `approveReview` call)
+- **"Approve & Apply"**: calls `approveReview`, then `invalidateAndRefetch()`, then closes modal
+- **"Skip & Close"**: closes modal immediately — transactions stay uncategorized
+
+---
+
+## What still needs to be done
+
+### 1. End-to-end testing
+- Import a BBVA file with merchants that have no matching rules
+- Verify the review panel appears with AI proposals
+- Test the category picker (existing + new categories)
+- Test rule dismiss/restore
+- Test "Approve & Apply" → verify transactions get categories, rules appear in DB
+- Test "Skip & Close" → verify transactions stay uncategorized
+- Test re-import after approval → same merchants should now be auto-categorized by the new rules
+
+### 2. Loading UX during AI call
+Currently the import button shows "Processing File..." the entire time, including the AI call (which can take 2–5 seconds). Consider adding a second loading message like "Asking AI for suggestions..." once the file parsing/insert is done. This would require splitting the import into two server actions (insert → then AI), or using a streaming approach.
+
+### 3. Edge cases to verify
+- What happens when AI proposes a new category but user changes it to an existing one before approving? ✓ Handled — `txEdits` state overrides the proposal.
+- What if `createCategory()` fails for a new category? Currently silently skipped — the transaction gets `category_id = null`. Consider surfacing this error.
+- Duplicate rule patterns across categorizations + standaloneRules — deduplicated by `match_pattern` in `aiPropose`.
+
+### 4. Optional improvements (not required for MVP)
+- Show a spinner/skeleton in the review panel while AI is running (requires async split)
+- Allow user to manually type a new category name in the picker (currently only AI-proposed new categories appear)
+- Add a "Rules" management page where users can view/edit/delete their merchant rules
+- Consider persisting the `pendingReview` state so a page refresh doesn't lose it
+
+---
+
+## Key files to read for context
+
+```
+src/lib/categorization/engine.ts          # existing rule engine (guessCategory)
+src/lib/categorization/ai-categorizer.ts  # new Gemini integration
+src/app/actions/import-transactions.ts    # import + approveReview actions
+src/components/ImportTransactionsForm.tsx # import modal UI with review panel
+src/types/database.ts                     # all canonical types incl. AI types
+src/lib/categories/constants.ts           # CATEGORY_ICONS, CATEGORY_COLORS
+src/app/actions/category-actions.ts       # createCategory() used in approveReview
+src/providers/DataProvider.tsx            # useData() — categories + invalidateAndRefetch
+```


### PR DESCRIPTION
Closes #23

## Summary

- Adds Gemini 2.0 Flash integration that runs after import when any transactions land as UNKNOWN (no rule match)
- Returns proposed categories + merchant rules; user reviews and approves before anything is committed
- Review panel appears inline in the import modal — "Approve & Apply" or "Skip & Close"
- Feature is silently disabled when `GEMINI_API_KEY` is not set; imports work exactly as before

## Changes

- `src/lib/categorization/ai-categorizer.ts` — new Gemini integration; sends full batch for context-aware grouping, returns `null` on any error (never breaks import)
- `src/app/actions/import-transactions.ts` — captures inserted IDs, triggers AI call, adds `approveReview` server action
- `src/components/ImportTransactionsForm.tsx` — review panel UI with category picker (existing + AI-proposed), per-rule dismiss, approve/skip actions
- `src/types/database.ts` — adds `AiCategoryProposal`, `AiTransactionProposal`, `AiRuleProposal`, `AiReviewProposal`
- `package.json` — adds `@google/generative-ai`

## Setup

Add to `.env.local` and Vercel env vars:
```
GEMINI_API_KEY=your_key_here
```
Free-tier key from https://aistudio.google.com/app/apikey is sufficient.

## Test plan

- [x] Import a BBVA file with merchants that have no matching rules — review panel appears with AI proposals
- [x] Category picker shows existing + AI-proposed new categories in separate `<optgroup>`
- [x] Individual rules can be dismissed; dismissed rules excluded from approve call
- [x] "Approve & Apply" — transactions get categories, new rules appear in DB
- [x] "Skip & Close" — transactions remain uncategorized
- [x] Re-import after approval — same merchants now auto-categorized by the new rules
- [x] Import without `GEMINI_API_KEY` — works normally, no review panel
- [x] Import where all transactions already have rule matches — no review panel