### PR TITLE
fix: fill all time buckets in Period Balance chart for proportional X-axis

### DIFF
--- a/e2e/overview.spec.ts
+++ b/e2e/overview.spec.ts
@@ -93,3 +93,24 @@ test('granularity toggle switches without a page reload', async ({ page }) => {
   await page.getByRole('button', { name: 'Months' }).first().click();
   await expect(page).toHaveURL('/overview');
 });
+
+test('Period Balance chart fills all months in a multi-month range', async ({ page }) => {
+  // A range spanning Jan 1 – May 14, 2026 (5 months)
+  await page.goto('/overview?from=2026-01-01&to=2026-05-14');
+
+  // Scope to the Period Balance card via its h3 heading's nearest rounded-xl ancestor
+  const card = page.getByRole('heading', { name: 'Period Balance', level: 3 })
+    .locator('xpath=ancestor::div[contains(@class,"rounded-xl")][1]');
+  await expect(card).toBeVisible();
+
+  // Chart must be rendering (not empty state)
+  await expect(card.getByRole('application')).toBeVisible();
+
+  // Switch to Months granularity on the Period Balance chart
+  await page.getByRole('button', { name: 'Months' }).first().click();
+
+  // Every month in the range must appear as an x-axis tick label —
+  // including months that have no transactions.
+  const ticks = card.locator('.recharts-xAxis .recharts-cartesian-axis-tick');
+  await expect(ticks).toHaveCount(5);
+});

--- a/e2e/overview.spec.ts
+++ b/e2e/overview.spec.ts
@@ -107,7 +107,7 @@ test('Period Balance chart fills all months in a multi-month range', async ({ pa
   await expect(card.getByRole('application')).toBeVisible();
 
   // Switch to Months granularity on the Period Balance chart
-  await page.getByRole('button', { name: 'Months' }).first().click();
+  await card.getByRole('button', { name: 'Months' }).click();
 
   // Every month in the range must appear as an x-axis tick label —
   // including months that have no transactions.

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -4,8 +4,8 @@ import { ensureSignedIn } from './helpers/auth';
 export { expect };
 
 export const test = base.extend<object>({
-  page: async ({ page }, use) => {
+  page: async ({ page }, provide) => {
     await ensureSignedIn(page);
-    await use(page);
+    await provide(page);
   },
 });

--- a/src/components/overview/PeriodBalanceChart.tsx
+++ b/src/components/overview/PeriodBalanceChart.tsx
@@ -12,7 +12,7 @@ import {
 } from "recharts";
 import { OverviewTransaction } from "@/types/database";
 import { formatDateRange } from "@/lib/format";
-import { Granularity, bucketKey, bucketLabel } from "@/lib/chart-utils";
+import { Granularity, bucketKey, bucketLabel, enumerateBuckets } from "@/lib/chart-utils";
 
 interface PeriodBalanceChartProps {
   transactions: OverviewTransaction[];
@@ -20,7 +20,7 @@ interface PeriodBalanceChartProps {
   to: string;
 }
 
-function buildSeries(transactions: OverviewTransaction[], granularity: Granularity, periodFrom: string) {
+function buildSeries(transactions: OverviewTransaction[], granularity: Granularity, from: string, to: string) {
   const netByBucket = new Map<string, number>();
   for (const t of transactions) {
     const key = bucketKey(t.date, granularity);
@@ -28,29 +28,11 @@ function buildSeries(transactions: OverviewTransaction[], granularity: Granulari
     netByBucket.set(key, (netByBucket.get(key) ?? 0) + delta);
   }
 
-  const startKey = bucketKey(periodFrom, granularity);
-  const startLabel = bucketLabel(startKey, granularity);
-
-  const keys = Array.from(netByBucket.keys()).sort();
   let running = 0;
-  const txPoints = keys.map((key) => {
-    running += netByBucket.get(key)!;
+  return enumerateBuckets(from, to, granularity).map((key) => {
+    running += netByBucket.get(key) ?? 0;
     return { label: bucketLabel(key, granularity), balance: Math.round(running * 100) / 100 };
   });
-
-  if (txPoints.length === 0) {
-    return [{ label: startLabel, balance: 0 }];
-  }
-
-  if (keys[0] !== startKey) {
-    // First transaction is after the period start — show a labeled 0 anchor.
-    return [{ label: startLabel, balance: 0 }, ...txPoints];
-  }
-
-  // First transaction falls in the same bucket as the period start.
-  // Use an unlabeled anchor so the chart starts at 0 and immediately
-  // rises/falls to the first value, without creating a duplicate X tick.
-  return [{ label: "", balance: 0 }, ...txPoints];
 }
 
 function formatEUR(v: number) {
@@ -65,7 +47,7 @@ const GRANULARITIES: { key: Granularity; label: string }[] = [
 
 export function PeriodBalanceChart({ transactions, from, to }: PeriodBalanceChartProps) {
   const [granularity, setGranularity] = useState<Granularity>("days");
-  const data = buildSeries(transactions, granularity, from);
+  const data = buildSeries(transactions, granularity, from, to);
 
   const dateSubtitle = formatDateRange(from, to);
 

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -7,7 +7,7 @@ export function isoWeek(dateStr: string): string {
   thursday.setDate(d.getDate() - (d.getDay() + 6) % 7 + 3);
   // Jan 4 is always in week 1 of Thursday's year
   const jan4 = new Date(thursday.getFullYear(), 0, 4);
-  const weekNum = 1 + Math.round((thursday.getTime() - jan4.getTime()) / 604800000);
+  const weekNum = 1 + Math.round((thursday.getTime() - jan4.getTime()) / 604800000); // ms per week
   return `${thursday.getFullYear()}-W${String(weekNum).padStart(2, "0")}`;
 }
 

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -23,3 +23,35 @@ export function bucketLabel(key: string, granularity: Granularity): string {
   const d = new Date(key + "T00:00:00");
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
+
+export function enumerateBuckets(from: string, to: string, granularity: Granularity): string[] {
+  if (granularity === "months") {
+    const [fy, fm] = from.slice(0, 7).split("-").map(Number);
+    const toKey = to.slice(0, 7);
+    const buckets: string[] = [];
+    let y = fy, m = fm;
+    while (true) {
+      const key = `${y}-${String(m).padStart(2, "0")}`;
+      if (key > toKey) break;
+      buckets.push(key);
+      m++;
+      if (m > 12) { m = 1; y++; }
+    }
+    return buckets;
+  }
+
+  // For days and weeks, step day-by-day and deduplicate week keys
+  const buckets: string[] = [];
+  const seen = new Set<string>();
+  const cursor = new Date(from + "T00:00:00");
+  const end = new Date(to + "T00:00:00");
+  while (cursor <= end) {
+    const key = bucketKey(cursor.toISOString().slice(0, 10), granularity);
+    if (!seen.has(key)) {
+      seen.add(key);
+      buckets.push(key);
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return buckets;
+}

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -2,10 +2,13 @@ export type Granularity = "days" | "weeks" | "months";
 
 export function isoWeek(dateStr: string): string {
   const d = new Date(dateStr + "T00:00:00");
-  const jan4 = new Date(d.getFullYear(), 0, 4);
-  const dayOfYear = Math.floor((d.getTime() - new Date(d.getFullYear(), 0, 0).getTime()) / 86400000);
-  const week = Math.ceil((dayOfYear + jan4.getDay() - 1) / 7);
-  return `${d.getFullYear()}-W${String(week).padStart(2, "0")}`;
+  // Advance to Thursday of this ISO week (weeks start Monday; Thursday is day 3 of each week)
+  const thursday = new Date(d);
+  thursday.setDate(d.getDate() - (d.getDay() + 6) % 7 + 3);
+  // Jan 4 is always in week 1 of Thursday's year
+  const jan4 = new Date(thursday.getFullYear(), 0, 4);
+  const weekNum = 1 + Math.round((thursday.getTime() - jan4.getTime()) / 604800000);
+  return `${thursday.getFullYear()}-W${String(weekNum).padStart(2, "0")}`;
 }
 
 export function bucketKey(dateStr: string, granularity: Granularity): string {
@@ -46,7 +49,8 @@ export function enumerateBuckets(from: string, to: string, granularity: Granular
   const cursor = new Date(from + "T00:00:00");
   const end = new Date(to + "T00:00:00");
   while (cursor <= end) {
-    const key = bucketKey(cursor.toISOString().slice(0, 10), granularity);
+    const localDate = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`;
+    const key = bucketKey(localDate, granularity);
     if (!seen.has(key)) {
       seen.add(key);
       buckets.push(key);


### PR DESCRIPTION
## Summary

Closes #25

- `buildSeries()` in `PeriodBalanceChart` now calls `enumerateBuckets(from, to, granularity)` instead of iterating only over transaction-keyed buckets. Empty buckets carry the running balance forward with a delta of 0, producing a dense, uniformly-spaced time series.
- `enumerateBuckets()` is a new helper in `chart-utils.ts` that steps through every day (deduplicating for weeks), month, or week bucket in the period.
- Fixed a DST bug in the cursor loop: uses local date getters instead of `toISOString()` to avoid losing a day after a spring-forward transition.
- Fixed a pre-existing `isoWeek()` bug where e.g. `2026-01-01` (a Thursday = ISO W01) was returned as `W00`. Replaced the hand-rolled algorithm with the standard Thursday-anchor approach.

## Conservative choices

The `ChangesChart` has the same sparse-bucket issue but was left untouched — it is out of scope for this issue and warrants its own fix.

## Test plan

1. Go to `/overview?from=2026-01-01&to=2026-05-14` and switch Period Balance to **Months** — all 5 months (Jan–May) must appear as x-axis ticks, including any that have no transactions.
2. Switch to **Days** — the chart should render a continuous line across the full range.
3. Switch to **Weeks** — one tick per week across the range.
4. Verify the new e2e test passes: `npx playwright test e2e/overview.spec.ts --grep "fills all months"`